### PR TITLE
fix stream issue

### DIFF
--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -49,6 +49,25 @@ async function handleRequest(request) {
   };
 
   const response = await fetch(fetchAPI, payload);
+  
+  const contentType = response.headers.get("Content-Type");
+  if (contentType && contentType.toLowerCase() === "text/event-stream") {
+    // Read the response body as text
+    const responseBody = await response.text();
+
+    // Add a newline character to the end of the response body
+    const modifiedBody = responseBody + "\n";
+
+    // Create a new response with the modified body and original headers
+    const modifiedResponse = new Response(modifiedBody, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+
+    return modifiedResponse;
+  }
+  
   return response
 
 }


### PR DESCRIPTION
https://github.com/haibbo/cf-openai-azure-proxy/issues/2

Azure and OpenAI have differences in stream mode, and a /n ending needs to be added at the end, otherwise the client will not receive the end flag. 