### PR TITLE
fix CORS policy blocked

### DIFF
--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -60,7 +60,9 @@ async function handleRequest(request) {
     body: typeof body === 'object' ? JSON.stringify(body) : '{}',
   };
 
-  const response = await fetch(fetchAPI, payload);
+  let response = await fetch(fetchAPI, payload);
+  response = new Response(response.body, response);
+  response.headers.set("Access-Control-Allow-Origin", "*");
 
   if (body?.stream != true){
     return response


### PR DESCRIPTION
修复前在浏览器内通过 fetch 请求时会因为 CORS policy 出错。

> Access to fetch at 'https://host/v1/chat/completions' from origin 'host' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.