### PR TITLE
Update cf-openai-azure-proxy.js

### DIFF
--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -7,7 +7,7 @@ const mapper = {
     'gpt-4': DEPLOY_NAME_GPT4
 };
 
-const apiVersion="2023-03-15-preview"
+const apiVersion="2023-05-15"
 
 addEventListener("fetch", (event) => {
   event.respondWith(handleRequest(event.request));


### PR DESCRIPTION
Following the recommendation of Azure OpenAI Service official documentation, upgrade the version number of Chat Completion API to "2023-05-15".
Official documentation link: [Azure OpenAI Chat Completion General Availability (GA)](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/whats-new#azure-openai-chat-completion-general-availability-ga)