### PR TITLE
feat: support use Azure API key starts with 'sk-'

### DIFF
--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -58,7 +58,7 @@ async function handleRequest(request) {
     method: request.method,
     headers: {
       "Content-Type": "application/json",
-      "api-key": authKey.replace('Bearer ', ''),
+      "api-key": authKey.replace(/Bearer (sk-)?/, ''),
     },
     body: typeof body === 'object' ? JSON.stringify(body) : '{}',
   };


### PR DESCRIPTION
部分第三方 ChatGPT 客户端限制了输入的 key 必须是 OpenAI 格式的 `sk-` 开头的 key，再他们还没修复或支持 Azure API 前，使本项目内代理对 Azure key 添加并替换 `sk-` 开头字符串以支持这些三方客户端