### PR TITLE
Updat API version to 2023-08-01-preview to support Function Calling, and update model mapping

### DIFF
--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -4,10 +4,12 @@ const resourceName=RESOURCE_NAME
 // The deployment name you chose when you deployed the model.
 const mapper = {
     'gpt-3.5-turbo': DEPLOY_NAME_GPT35,
-    'gpt-4': DEPLOY_NAME_GPT4
+    'gpt-3.5-turbo-16k': DEPLOY_NAME_GPT35_16K,
+    'gpt-4': DEPLOY_NAME_GPT4,
+    'gpt-4-32k': DEPLOY_NAME_GPT4_32K,
 };
 
-const apiVersion="2023-05-15"
+const apiVersion="2023-08-01-preview"
 
 addEventListener("fetch", (event) => {
   event.respondWith(handleRequest(event.request));


### PR DESCRIPTION
Function calling has been supported by Azure OpenAI since the 2023-07-01-preview API version. 

However, the most recent API version, 2023-08-01-preview, has been tested and found to be perfectly functional. 

Therefore, this pull request proposes an update to the API version to 2023-08-01-preview.

* [How to use function calling with Azure OpenAI Service (Preview)
](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/function-calling)
* [Azure OpenAI Service REST API reference](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions)