### PR TITLE
Update cf-openai-azure-proxy.js

### DIFF
--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -4,6 +4,7 @@ const resourceName=RESOURCE_NAME
 // The deployment name you chose when you deployed the model.
 const mapper = {
     'gpt-3.5-turbo': DEPLOY_NAME_GPT35,
+    'gpt-3.5-turbo-0613': DEPLOY_NAME_GPT35,
     'gpt-4': DEPLOY_NAME_GPT4,
 };
 


### PR DESCRIPTION
Fix the issue when some repository will use the model name like 'gpt-3.5-turbo-0613'. It will throw 'Invalid response object from API: 'Missing model mapper' (HTTP response code was 403)'