### PR TITLE
Raise upstream timeout default and expose rate-limit headers

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -10,60 +10,54 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        push: true
-        tags: haibbo/cf-openai-azure-proxy:${{ github.ref_name }}
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        push: true
-        tags: |
-          haibbo/cf-openai-azure-proxy:${{ github.ref_name }}
-          haibbo/cf-openai-azure-proxy:latest
-        platforms: linux/amd64,linux/arm64/v8
-    - name: Create GitHub Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.ACTIONS_RELEASE_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        body: |
-          Release notes for ${{ github.ref }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            haibbo/cf-openai-azure-proxy:${{ github.ref_name }}
+            haibbo/cf-openai-azure-proxy:latest
+          platforms: linux/amd64,linux/arm64/v8
 
-          ```sh
-          docker run -d -p 8787:8787 -t cf-azure-openai-proxy \
-          --env RESOURCE_NAME=codegpt \
-          --env DEPLOY_NAME=gpt3 \
-          --env DEPLOY_NAME_GPT4=gpt4 \
-          haibbo/cf-openai-azure-proxy:latest
-          ```
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_RELEASE_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Release notes for ${{ github.ref }}
 
+            ```sh
+            docker run --rm -p 8787:8787 \
+              -e AZURE_API_KEY=your-azure-key \
+              -e AZURE_OAI_ENDPOINT=https://your-resource.cognitiveservices.azure.com \
+              -e CLIENT_API_KEYS=sk-demo \
+              haibbo/cf-openai-azure-proxy:latest
+            ```
 
-          Docker image is available at:
-          - `haibbo/cf-openai-azure-proxy:${{ github.ref_name }}`
-          - `haibbo/cf-openai-azure-proxy:latest`
+            Then configure your client with:
 
-          Enjoy!
-        draft: false
-        prerelease: false
+            - Base URL: `http://127.0.0.1:8787/v1`
+            - API Key: `sk-demo`
 
-
-
+            Docker image is available at:
+            - `haibbo/cf-openai-azure-proxy:${{ github.ref_name }}`
+            - `haibbo/cf-openai-azure-proxy:latest`
+          draft: false
+          prerelease: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,52 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check worker syntax
+        run: node --check --experimental-default-type=module cf-openai-azure-proxy.js
+
+      - name: Check entrypoint shell syntax
+        run: sh -n docker-entrypoint.sh
+
+      - name: Validate local README links
+        run: |
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          root = Path(".").resolve()
+          readmes = [root / "README.md", root / "README_en.md"]
+          missing = []
+
+          pattern = re.compile(r"\]\((\./[^)#]+)")
+
+          for readme in readmes:
+            text = readme.read_text(encoding="utf-8")
+            for match in pattern.finditer(text):
+              rel = match.group(1)
+              target = (readme.parent / rel).resolve()
+              if not target.exists():
+                missing.append(f"{readme.name}: missing {rel}")
+
+          if missing:
+            raise SystemExit("\n".join(missing))
+
+          print("All local README links resolve.")
+          PY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM node:18.12-slim
+FROM node:20-slim
 
 WORKDIR /app
 
-# 安装 Cloudflare Workers CLI 工具
-RUN npm install -g wrangler@2.15.0
+RUN npm install -g wrangler@4
 
 ENV WRANGLER_SEND_METRICS=false
 
-ENV DEPLOY_NAME_GPT35=""
-ENV DEPLOY_NAME_GPT4=""
+COPY cf-openai-azure-proxy.js wrangler.toml docker-entrypoint.sh ./
 
-# 复制 Workers 脚本到镜像
-COPY cf-openai-azure-proxy.js .
+RUN chmod +x /app/docker-entrypoint.sh
 
-# 启动本地开发服务器
-CMD wrangler dev cf-openai-azure-proxy.js --local --var RESOURCE_NAME:$RESOURCE_NAME DEPLOY_NAME_GPT35:$DEPLOY_NAME_GPT35 DEPLOY_NAME_GPT4:$DEPLOY_NAME_GPT4
+EXPOSE 8787
+
+CMD ["/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -3,63 +3,96 @@
 <a href="./README_en.md">English</a> |
 <a href="./README.md">中文</a>
 
-> 大多数 OpenAI 客户端不支持 Azure OpenAI Service，但Azure OpenAI Service的申请和绑卡都非常简单，并且还提供了免费的额度。此脚本使用免费的 Cloudflare Worker 作为代理，使得支持 OpenAI 的客户端可以直接使用 Azure OpenAI Service。
+> 一个跑在 Cloudflare Workers 上的代理，把 **OpenAI 兼容接口** 转到 **Azure AI Foundry**。支持三种上游形态：经典 Azure OpenAI、Responses API、Azure AI Model Inference（Grok/DeepSeek/Llama 等）。
 
-### 支持模型:
-- GPT-3
-- GPT-4
-- DALL-E-3
-  
-模型子类添加非常容易, 参考下面的使用说明
-  
-### 项目说明:
-- 我没有服务器可以使用吗?
-    - 这段脚本跑在Cloudflare Worker, 不需要服务器, 不需要绑卡, 每天10W次请求 免费
-- 我没有自己的域名可以使用吗?
-    - 也可以, 参考: https://github.com/haibbo/cf-openai-azure-proxy/issues/3
-- 实现打印机模式：
-    - Azure OpenAI Service's 回复是一段一段回复的
-    - 返回给客户端的时候， 本项目拆出一条条的消息, 依次给， 达到打印机模式
-- 项目也支持 Docker 部署（基于 wrangler）
+## 特性
 
-### 部署
-代理 OpenAI 的请求到 Azure OpenAI Serivce，代码部署步骤：
+- ✅ `/v1/chat/completions` — 经典 chat（GPT-4o、o1 等）+ Model Inference（Grok、DeepSeek 等）
+- ✅ `/v1/responses` — Azure OpenAI Responses API（gpt-5.4 等）
+- ✅ `/v1/completions`、`/v1/embeddings`、`/v1/images/generations`、`/v1/audio/{speech,transcriptions,translations}`、`/v1/images/edits`
+- ✅ `/v1/models` — 根据 `MODEL_MAPPING` 自动列出
+- ✅ 客户端 API Key 白名单（`CLIENT_API_KEYS`），Azure 密钥不暴露给客户端
+- ✅ 流式响应原生透传（SSE）
+- ✅ 支持同一个 Worker 同时代理**两个 Azure 资源**（一个 OpenAI、一个 Model Inference）
 
-1. 注册并登录到 Cloudflare 账户
-2. 创建一个新的 Cloudflare Worker
-3. 将 [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js) 复制并粘贴到 Cloudflare Worker 编辑器中
-4. 通过修改或环境变量调整 resourceName 和 deployment mapper 的值
-5. 保存并部署 Cloudflare Worker
-6. https://github.com/haibbo/cf-openai-azure-proxy/issues/3 **可选**绑定自定义域名: 在 Worker 详情页 -> Trigger -> Custom Domains 中为这个 Worker 添加一个自定义域名
+## 部署
 
+### 方式一：控制台粘贴
 
-### 使用说明
+1. 登录 Cloudflare → Workers & Pages → Create Worker
+2. 把 [`cf-openai-azure-proxy.js`](./cf-openai-azure-proxy.js) 整个内容粘贴进去
+3. 部署后进入 **Settings → Variables**，配置下面的环境变量
+4. 可选：绑定自定义域名
 
-先得到 resourceName 和 deployment mapper, 登录到Azure的后台:
+### 方式二：wrangler CLI
 
-<img width="777" src="https://user-images.githubusercontent.com/1295315/233124125-1ea95665-ffab-4b5c-a7ba-26f31f1bb0b3.png" alt="env" />
+```bash
+npm i -g wrangler
+wrangler login
 
-#### 这里有两种做法:
-- 直接修改他们的值, 如:
-```js
-// The name of your Azure OpenAI Resource.
-const resourceName="codegpt"
+# 编辑 wrangler.toml 里的 endpoint
+wrangler secret put AZURE_API_KEY       # 粘贴你的 Azure key
+wrangler secret put CLIENT_API_KEYS     # 粘贴 sk-xxx,sk-yyy
+wrangler secret put MODEL_MAPPING       # 粘贴 JSON 字符串
 
-// deployment model mapper
-const mapper = {
-     'gpt-3.5-turbo': 'gpt3',
-     'gpt-4': 'gpt4',
-     'dall-e-3': 'dalle3' 
-   };
-其他的map规则直接按这样的格式续写即可
+wrangler deploy
 ```
-- 或者通过 cloudflare worker 控制台, 进入 Workers script > Settings > Add variable under Environment Variables.
 
-  <img width="777" src="https://user-images.githubusercontent.com/1295315/233384224-aa6581f0-26a4-49cf-ae25-4dfb466143da.png" alt="env" />
+## 环境变量
 
-### 客户端
-以 OpenCat 为例: 自定义 API 域名填写 第六步绑定的域名:
+| 变量 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `AZURE_API_KEY` | Secret | ✅ | Azure Foundry 密钥（两个资源共用） |
+| `AZURE_OAI_ENDPOINT` | Var | ✅ | Azure OpenAI 资源根 URL，例如 `https://yoyo.cognitiveservices.azure.com` |
+| `AZURE_INFER_ENDPOINT` | Var | 用到 Grok/DeepSeek 等才必填 | 例如 `https://waytoagi.services.ai.azure.com` |
+| `AZURE_OAI_API_VERSION` | Var | ⬜ | 默认 `2025-04-01-preview` |
+| `AZURE_INFER_API_VERSION` | Var | ⬜ | 默认 `2024-05-01-preview` |
+| `MODEL_MAPPING` | Var/Secret | ⬜ | JSON 字符串；不填则用代码内置默认映射 |
+| `CLIENT_API_KEYS` | Secret | ⬜ | 逗号分隔的客户端 key；不填则透传客户端 Authorization 直连 Azure |
 
-<img width="339" src="https://user-images.githubusercontent.com/1295315/229820705-ab2ad1d1-8795-4670-97b4-16a0f9fdebba.png" alt="opencat" />
+### `MODEL_MAPPING` 示例
 
-我已经尝试了多种客户端, 如果遇到其他客户端有问题, 欢迎创建issue.
+```json
+{
+  "gpt-5.4":        { "backend": "oai",   "deployment": "gpt-5.4" },
+  "gpt-4o":         { "backend": "oai",   "deployment": "gpt-4o" },
+  "gpt-image-1.5":  { "backend": "oai",   "deployment": "gpt-image-1.5", "apiVersion": "2024-02-01" },
+  "dall-e-3":       { "backend": "oai",   "deployment": "dall-e-3" },
+  "text-embedding-3-small": { "backend": "oai", "deployment": "text-embedding-3-small" },
+  "whisper-1":      { "backend": "oai",   "deployment": "whisper" },
+
+  "grok-4-20":      { "backend": "infer", "deployment": "grok-4-20" },
+  "deepseek-r1":    { "backend": "infer", "deployment": "DeepSeek-R1" },
+  "deepseek-v3":    { "backend": "infer", "deployment": "DeepSeek-V3" }
+}
+```
+
+字段说明：
+- `backend`：`oai` 走 `AZURE_OAI_ENDPOINT`（支持 chat/completions + responses + images + embeddings + audio）；`infer` 走 `AZURE_INFER_ENDPOINT`（仅支持 chat/completions + embeddings）
+- `deployment`：你在 Azure Foundry 里创建 deployment 时填的名字
+- `apiVersion`：可选，覆盖这个模型专用的 api-version（比如 `gpt-image-1.5` 用 `2024-02-01`）
+
+## 客户端接入
+
+在任何支持 OpenAI API 的软件里：
+
+- **Base URL**：`https://<your-worker>.workers.dev/v1`
+- **API Key**：`CLIENT_API_KEYS` 里你自己设的那个 `sk-xxx`（如果没开白名单，就填 Azure key）
+
+对于支持 Responses API 的客户端（新版 Cherry Studio、ChatWise、OpenAI SDK ≥ 1.x 的 responses 调用），同一个 base URL 即可，`model` 填 `gpt-5.4` 这种，走的是 `/v1/responses`。
+
+## 请求路由表
+
+| 客户端请求 | Model 在 mapping 的 backend | 上游 URL |
+|---|---|---|
+| `POST /v1/chat/completions` | `oai` | `{OAI}/openai/deployments/{depl}/chat/completions` |
+| `POST /v1/chat/completions` | `infer` | `{INFER}/models/chat/completions` |
+| `POST /v1/responses` | `oai` | `{OAI}/openai/responses` |
+| `POST /v1/images/generations` | `oai` | `{OAI}/openai/deployments/{depl}/images/generations` |
+| `POST /v1/embeddings` | `oai` / `infer` | 同上两种之一 |
+| `POST /v1/audio/*` | `oai` | `{OAI}/openai/deployments/{depl}/audio/*`（multipart 透传） |
+| `GET /v1/models` | — | 本地从 mapping 生成 |
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -141,16 +141,73 @@ OpenAI-compatible client
 
 ## 部署方式
 
-当前推荐方式是直接用 Wrangler 部署 Cloudflare Worker。
+推荐先走 Cloudflare Dashboard 手动部署，第一次上手最直观；`Wrangler` 更适合后续更新、版本化配置和本地调试。
 
-### 1. 准备项目
+### 方式一：Cloudflare Dashboard 手动部署（推荐）
+
+#### 1. 创建 Worker
+
+- 登录 Cloudflare Dashboard
+- 进入 Workers & Pages
+- 新建一个 Worker
+
+#### 2. 复制脚本
+
+把仓库里的 [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js) 全部复制到 Cloudflare Worker 编辑器中，覆盖默认示例代码。
+
+#### 3. 配置 Variables 和 Secrets
+
+在 Worker 的 Settings / Variables 中配置这些值：
+
+- 非敏感变量可直接添加为普通变量
+  - `AZURE_OAI_ENDPOINT`
+  - `AZURE_INFER_ENDPOINT`
+  - `AZURE_OAI_API_VERSION`
+  - `AZURE_INFER_API_VERSION`
+- 敏感变量建议添加为 secret
+  - `AZURE_API_KEY`
+  - `CLIENT_API_KEYS`
+  - `MODEL_MAPPING`
+
+可以先只配最小必需项：
+
+- `AZURE_API_KEY`
+- `AZURE_OAI_ENDPOINT` 或 `AZURE_INFER_ENDPOINT`
+- `CLIENT_API_KEYS`（建议）
+
+如果你想自定义模型映射，再额外配置 `MODEL_MAPPING`。
+
+#### 4. 部署并拿到地址
+
+保存并部署后，Cloudflare 会给你一个 Worker URL。
+
+把下面这个地址填到你的 OpenAI 兼容客户端里：
+
+```text
+https://your-worker.your-subdomain.workers.dev/v1
+```
+
+如果你有自己的域名，也可以在 Worker 的域名 / 路由设置里绑定自定义域名，再把 `https://your-domain/v1` 配给客户端。
+
+### 方式二：Wrangler CLI 部署（可选）
+
+`Wrangler` 不是必须的。它的作用是把“在网页里复制代码、手动填变量、点击发布”的流程改成命令行方式，更适合反复更新。
+
+这个仓库里：
+
+- [wrangler.toml](./wrangler.toml) 指定了入口文件 `main = "cf-openai-azure-proxy.js"`
+- 执行 `wrangler deploy` 时，会把 [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js) 上传成 Worker
+- `[vars]` 中的非敏感变量会一并带上
+- `AZURE_API_KEY`、`CLIENT_API_KEYS`、`MODEL_MAPPING` 这类敏感值仍建议用 secret
+
+#### 1. 安装并登录
 
 ```bash
 npm i -g wrangler
 wrangler login
 ```
 
-### 2. 配置变量
+#### 2. 配置变量
 
 `wrangler.toml` 中的 `[vars]` 可放非敏感配置，例如：
 
@@ -170,13 +227,13 @@ wrangler secret put CLIENT_API_KEYS
 wrangler secret put MODEL_MAPPING
 ```
 
-### 3. 部署
+#### 3. 部署
 
 ```bash
 wrangler deploy
 ```
 
-部署完成后，会拿到一个 Worker URL。把 `{WORKER_URL}/v1` 配到你的 OpenAI 兼容客户端即可。
+部署完成后，同样把 `{WORKER_URL}/v1` 配到你的 OpenAI 兼容客户端即可。
 
 ## 客户端怎么填
 
@@ -189,10 +246,11 @@ wrangler deploy
 
 ## 注意事项
 
+- 手动部署和 Wrangler 部署的运行效果是一样的，区别主要在发布方式
 - `GET /v1/models` 返回的是映射表里的模型列表，不是 Azure 自动探测结果
 - 只有配置了相应 endpoint 和 deployment 的模型才能真正调用成功
 - 本项目默认只做协议转换和透传，不做重试、缓存、配额、审计或多租户管理
-- 仓库也提供 Docker 镜像，主要用于本地运行 `wrangler dev --local`；部署到 Cloudflare 仍推荐直接使用 Wrangler
+- 仓库也提供 Docker 镜像，主要用于本地运行 `wrangler dev --local`，不是 Cloudflare 线上部署的必需项
 
 ## 主要文件
 

--- a/README.md
+++ b/README.md
@@ -3,94 +3,203 @@
 <a href="./README_en.md">English</a> |
 <a href="./README.md">中文</a>
 
-> 大多数 OpenAI 客户端不支持 Azure OpenAI / Azure AI Foundry，但 Azure 的申请和绑卡都非常简单，并且还提供了免费的额度。此脚本使用免费的 Cloudflare Worker 作为代理，使得支持 OpenAI 的客户端可以直接使用 Azure AI Foundry 上的各种模型（包括 OpenAI 系、Grok、DeepSeek、Llama 等）。
+> 一个运行在 Cloudflare Workers 上的 OpenAI 兼容代理。它把客户端发来的 `/v1/*` 请求转成 Azure OpenAI / Azure AI Foundry 可接受的上游请求，让只支持 OpenAI API 的客户端也能接入 Azure 上部署的模型。
 
-### 支持模型:
-- GPT 系列（GPT-4o、GPT-5.4、o1、o3 等）
-- 图像生成（DALL-E-3、gpt-image-1、gpt-image-1.5）
-- Embeddings（text-embedding-3-small / large）
-- 语音（Whisper、TTS）
-- Grok 系列（通过 Azure AI Model Inference）
-- DeepSeek / Llama 等第三方模型（通过 Azure AI Model Inference）
+## 这个项目做什么
 
-模型子类添加非常容易, 参考下面的使用说明。
+很多客户端只支持 OpenAI 风格接口，但不直接支持 Azure OpenAI / Azure AI Foundry。本项目提供一个很轻量的协议转换层：
 
-### 项目说明:
-- 我没有服务器可以使用吗?
-    - 这段脚本跑在 Cloudflare Worker, 不需要服务器, 不需要绑卡, 每天 10W 次请求 免费
-- 我没有自己的域名可以使用吗?
-    - 也可以, 参考: https://github.com/haibbo/cf-openai-azure-proxy/issues/3
-- 同时支持哪些 Azure 接口形态？
-    - 经典 Azure OpenAI（`/openai/deployments/{name}/*`）
-    - Responses API（`/openai/responses`，对应客户端的 `/v1/responses`）
-    - Azure AI Model Inference（`/models/*`，跑 Grok/DeepSeek/Llama 等非 OpenAI 模型）
-- 一个 Worker 能不能同时代理多个 Azure 资源？
-    - 可以。本项目设计成 `AZURE_OAI_ENDPOINT`（OpenAI 资源）+ `AZURE_INFER_ENDPOINT`（AI Foundry 第三方模型资源）并存
-- 流式响应支持吗？
-    - 支持。SSE 原生透传，无人为延迟
-- 项目也支持 Docker 部署（基于 wrangler）
+- 客户端继续按 OpenAI 方式请求 `/v1/chat/completions`、`/v1/responses`、`/v1/embeddings` 等接口
+- Cloudflare Worker 根据 `model` 字段查找映射关系
+- 再把请求转发到 Azure OpenAI 或 Azure AI Model Inference
 
-### 部署
-代理 OpenAI 的请求到 Azure AI Foundry，代码部署步骤：
+它是一个无状态代理，不是聊天应用本体，也不包含数据库、计费、用户系统或管理后台。
 
-1. 注册并登录到 Cloudflare 账户
-2. 创建一个新的 Cloudflare Worker
-3. 将 [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js) 复制并粘贴到 Cloudflare Worker 编辑器中
-4. 通过环境变量配置 `AZURE_OAI_ENDPOINT`、`AZURE_API_KEY` 等（详见下方"使用说明"）
-5. 保存并部署 Cloudflare Worker
-6. **可选**绑定自定义域名: 在 Worker 详情页 -> Trigger -> Custom Domains 中为这个 Worker 添加一个自定义域名，参考 https://github.com/haibbo/cf-openai-azure-proxy/issues/3
+## 当前支持的能力
 
-也可以用 wrangler CLI 部署：
+- OpenAI 兼容入口
+  - `POST /v1/chat/completions`
+  - `POST /v1/responses`
+  - `POST /v1/completions`
+  - `POST /v1/embeddings`
+  - `POST /v1/images/generations`
+  - `POST /v1/audio/speech`
+  - `POST /v1/audio/transcriptions`
+  - `POST /v1/audio/translations`
+  - `POST /v1/images/edits`
+  - `POST /v1/images/variations`
+  - `GET /v1/models`
+- Azure OpenAI 经典接口
+  - `/openai/deployments/{deployment}/*`
+- Azure OpenAI Responses API
+  - `/openai/responses`
+- Azure AI Model Inference
+  - `/models/*`
+- SSE 流式透传
+- 简单客户端鉴权
+  - 用 `CLIENT_API_KEYS` 给你的 Worker 再包一层访问控制
+
+## 支持的模型类型
+
+默认映射里已经给了这些示例：
+
+- GPT 系列
+  - `gpt-5.4`
+  - `gpt-4o`
+  - `gpt-4o-mini`
+  - `o1`
+  - `o3-mini`
+- 图像
+  - `gpt-image-1`
+  - `gpt-image-1.5`
+  - `dall-e-3`
+- Embeddings
+  - `text-embedding-3-small`
+  - `text-embedding-3-large`
+- 语音
+  - `whisper-1`
+  - `tts-1`
+- Azure AI Foundry 第三方模型
+  - `grok-4-20`
+  - `grok-3`
+  - `deepseek-r1`
+  - `deepseek-v3`
+  - `llama-3.3-70b`
+
+实际可用模型取决于你在 Azure 中部署了什么，以及 `MODEL_MAPPING` 如何配置。
+
+## 工作方式
+
+请求链路如下：
+
+```text
+OpenAI-compatible client
+  -> /v1/chat/completions | /v1/responses | /v1/embeddings | ...
+  -> Cloudflare Worker
+  -> 校验 Authorization / CLIENT_API_KEYS
+  -> 读取 body.model
+  -> 根据 MODEL_MAPPING 找到 backend + deployment
+  -> 转发到对应 Azure 上游
+     - backend=oai   -> {AZURE_OAI_ENDPOINT}/openai/...
+     - backend=infer -> {AZURE_INFER_ENDPOINT}/models/...
+  -> 把响应原样返回给客户端
+```
+
+## 环境变量
+
+在 Cloudflare Workers 的 Variables / Secrets 中配置：
+
+| 变量 | 必填 | 说明 |
+|---|---|---|
+| `AZURE_API_KEY` | 推荐 | Azure API Key。设置后，Worker 用它访问 Azure |
+| `AZURE_OAI_ENDPOINT` | 使用 Azure OpenAI 时必填 | 例如 `https://your-resource.cognitiveservices.azure.com` |
+| `AZURE_INFER_ENDPOINT` | 使用 Azure AI Model Inference 时必填 | 例如 `https://your-project.services.ai.azure.com` |
+| `CLIENT_API_KEYS` | 推荐 | 逗号分隔，作为客户端访问你这个代理时使用的 key |
+| `AZURE_OAI_API_VERSION` | 否 | 默认 `2025-04-01-preview` |
+| `AZURE_INFER_API_VERSION` | 否 | 默认 `2024-05-01-preview` |
+| `MODEL_MAPPING` | 否 | JSON 字符串；不填时使用代码内置默认映射 |
+
+说明：
+
+- 如果设置了 `CLIENT_API_KEYS`，客户端必须用其中某个 key 访问 Worker
+- 如果没有设置 `CLIENT_API_KEYS`，Worker 会放行客户端请求
+- 如果同时也没有设置 `AZURE_API_KEY`，则会尝试把客户端 `Authorization: Bearer ...` 当作 Azure key 继续透传
+
+## MODEL_MAPPING 格式
+
+`MODEL_MAPPING` 是一个 JSON 对象，key 是客户端使用的模型名，value 描述这个模型要转发到哪个 Azure 后端和 deployment。
+
+示例：
+
+```json
+{
+  "gpt-5.4": {
+    "backend": "oai",
+    "deployment": "gpt-5.4"
+  },
+  "gpt-4o": {
+    "backend": "oai",
+    "deployment": "gpt-4o"
+  },
+  "grok-4-20": {
+    "backend": "infer",
+    "deployment": "grok-4-20"
+  },
+  "deepseek-r1": {
+    "backend": "infer",
+    "deployment": "deepseek-r1"
+  }
+}
+```
+
+规则：
+
+- `backend: "oai"` 表示走 Azure OpenAI
+- `backend: "infer"` 表示走 Azure AI Model Inference
+- `deployment` 填你在 Azure 中实际创建的 deployment 名
+- 可选 `apiVersion` 可覆盖默认 API 版本
+
+## 部署方式
+
+当前推荐方式是直接用 Wrangler 部署 Cloudflare Worker。
+
+### 1. 准备项目
 
 ```bash
 npm i -g wrangler
 wrangler login
+```
+
+### 2. 配置变量
+
+`wrangler.toml` 中的 `[vars]` 可放非敏感配置，例如：
+
+```toml
+[vars]
+AZURE_OAI_ENDPOINT      = "https://your-resource.cognitiveservices.azure.com"
+AZURE_INFER_ENDPOINT    = "https://your-project.services.ai.azure.com"
+AZURE_OAI_API_VERSION   = "2025-04-01-preview"
+AZURE_INFER_API_VERSION = "2024-05-01-preview"
+```
+
+敏感信息使用 secret：
+
+```bash
 wrangler secret put AZURE_API_KEY
 wrangler secret put CLIENT_API_KEYS
+wrangler secret put MODEL_MAPPING
+```
+
+### 3. 部署
+
+```bash
 wrangler deploy
 ```
 
-### 使用说明
+部署完成后，会拿到一个 Worker URL。把 `{WORKER_URL}/v1` 配到你的 OpenAI 兼容客户端即可。
 
-先得到 Azure 资源名和各个 deployment 名, 登录到 Azure AI Foundry 后台查看。
+## 客户端怎么填
 
-#### 环境变量列表
+以 OpenAI 兼容客户端为例：
 
-| 变量 | 必填 | 说明 |
-|---|---|---|
-| `AZURE_API_KEY` | ✅ | Azure 密钥（Secret） |
-| `AZURE_OAI_ENDPOINT` | ✅ | 例 `https://yoyo.cognitiveservices.azure.com` |
-| `AZURE_INFER_ENDPOINT` | 用 Grok/DeepSeek 才要 | 例 `https://waytoagi.services.ai.azure.com` |
-| `CLIENT_API_KEYS` | 推荐 | 逗号分隔，例 `sk-mykey1,sk-mykey2` |
-| `AZURE_OAI_API_VERSION` | ⬜ | 默认 `2025-04-01-preview` |
-| `AZURE_INFER_API_VERSION` | ⬜ | 默认 `2024-05-01-preview` |
-| `MODEL_MAPPING` | ⬜ | JSON 字符串，不填用代码内置默认映射 |
+- Base URL: `https://your-worker.your-subdomain.workers.dev/v1`
+- API Key: `CLIENT_API_KEYS` 中你自定义的某个 key
 
-<img width="777" src="https://user-images.githubusercontent.com/1295315/233384224-aa6581f0-26a4-49cf-ae25-4dfb466143da.png" alt="env" />
+对于支持新版 Responses API 的客户端，同样填这个 Base URL 即可，代理会把 `/v1/responses` 自动转给 Azure 的 `/openai/responses`。
 
-#### 这里有两种做法:
+## 注意事项
 
-- 直接修改代码顶部 `DEFAULT_MAPPING` 的值, 如:
+- `GET /v1/models` 返回的是映射表里的模型列表，不是 Azure 自动探测结果
+- 只有配置了相应 endpoint 和 deployment 的模型才能真正调用成功
+- 本项目默认只做协议转换和透传，不做重试、缓存、配额、审计或多租户管理
+- 仓库也提供 Docker 镜像，主要用于本地运行 `wrangler dev --local`；部署到 Cloudflare 仍推荐直接使用 Wrangler
 
-```js
-const DEFAULT_MAPPING = {
-  "gpt-4o":       { backend: "oai",   deployment: "gpt-4o" },
-  "gpt-5.4":      { backend: "oai",   deployment: "gpt-5.4" },
-  "dall-e-3":     { backend: "oai",   deployment: "dall-e-3" },
-  "grok-4-20":    { backend: "infer", deployment: "grok-4-20" },
-  "deepseek-r1":  { backend: "infer", deployment: "deepseek-r1" },
-};
-// 其他的 map 规则直接按这样的格式续写即可
-// backend: "oai" 走 Azure OpenAI，"infer" 走 Azure AI Model Inference
-```
+## 主要文件
 
-- 或者通过 cloudflare worker 控制台, 进入 Workers script > Settings > Variables and Secrets, 把整个 JSON 作为 `MODEL_MAPPING` 变量填进去。
+- [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js): 当前主 Worker 实现
+- [wrangler.toml](./wrangler.toml): Worker 配置
+- [cf-openai-palm-proxy.js](./cf-openai-palm-proxy.js): 早期 PaLM 代理脚本，和当前 Azure 主实现无关
 
-### 客户端
-以 OpenCat 为例: 自定义 API 域名填写绑定的域名（加 `/v1` 后缀），API Key 填 `CLIENT_API_KEYS` 里你自己设的某个 `sk-xxx`：
+## License
 
-<img width="339" src="https://user-images.githubusercontent.com/1295315/229820705-ab2ad1d1-8795-4670-97b4-16a0f9fdebba.png" alt="opencat" />
-
-对于支持 Responses API 的新版客户端（Cherry Studio、ChatWise 等），同样填上面的 base URL 即可，代理会自动把 `/v1/responses` 转给 Azure。
-
-我已经尝试了多种客户端, 如果遇到其他客户端有问题, 欢迎创建 issue。
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,95 +3,172 @@
 <a href="./README_en.md">English</a> |
 <a href="./README.md">中文</a>
 
-> 一个跑在 Cloudflare Workers 上的代理，把 **OpenAI 兼容接口** 转到 **Azure AI Foundry**。支持三种上游形态：经典 Azure OpenAI、Responses API、Azure AI Model Inference（Grok/DeepSeek/Llama 等）。
+> 跑在 **Cloudflare Workers** 上的代理，把 **OpenAI 兼容接口** 转成 **Azure AI Foundry** 的请求。让所有支持 OpenAI 的客户端软件都能直接用你的 Azure 模型。
+
+## 它能做什么
+
+Azure AI Foundry 暴露的是**三种互不相同**的 API：经典 Azure OpenAI、新版 Responses API、Azure AI Model Inference（跑 Grok / DeepSeek / Llama 等非 OpenAI 模型）。
+
+这个代理把它们统一到 OpenAI 的 `/v1/*` 规范，任何 OpenAI 客户端（NextChat、LobeChat、Cherry Studio、ChatBox、Zed、Cursor、VS Code Copilot 替代插件等）都能直接用。
 
 ## 特性
 
-- ✅ `/v1/chat/completions` — 经典 chat（GPT-4o、o1 等）+ Model Inference（Grok、DeepSeek 等）
-- ✅ `/v1/responses` — Azure OpenAI Responses API（gpt-5.4 等）
-- ✅ `/v1/completions`、`/v1/embeddings`、`/v1/images/generations`、`/v1/audio/{speech,transcriptions,translations}`、`/v1/images/edits`
-- ✅ `/v1/models` — 根据 `MODEL_MAPPING` 自动列出
-- ✅ 客户端 API Key 白名单（`CLIENT_API_KEYS`），Azure 密钥不暴露给客户端
-- ✅ 流式响应原生透传（SSE）
-- ✅ 支持同一个 Worker 同时代理**两个 Azure 资源**（一个 OpenAI、一个 Model Inference）
+- ✅ `/v1/chat/completions` — 自动路由到经典 chat（GPT-4o、o1、gpt-5.4…）或 Model Inference（Grok、DeepSeek、Llama…）
+- ✅ `/v1/responses` — Azure OpenAI Responses API（推理模型的新调用形态）
+- ✅ `/v1/embeddings` / `/v1/images/generations` / `/v1/audio/{speech,transcriptions,translations}` / `/v1/images/edits`
+- ✅ `/v1/models` — 自动从 mapping 生成列表
+- ✅ 客户端 API Key 白名单，Azure 密钥不暴露给客户端
+- ✅ SSE 流式响应原生透传（无降速）
+- ✅ 同一个 Worker 同时代理**两个 Azure 资源**（OpenAI 资源 + Model Inference 资源）
 
-## 部署
+---
 
-### 方式一：控制台粘贴
+## 快速开始（5 分钟）
 
-1. 登录 Cloudflare → Workers & Pages → Create Worker
-2. 把 [`cf-openai-azure-proxy.js`](./cf-openai-azure-proxy.js) 整个内容粘贴进去
-3. 部署后进入 **Settings → Variables**，配置下面的环境变量
-4. 可选：绑定自定义域名
+### 1. 在 Cloudflare 部署 Worker
 
-### 方式二：wrangler CLI
+**方式 A — 控制台粘贴**（零依赖，推荐新手）
+
+1. 登录 [Cloudflare](https://dash.cloudflare.com) → **Workers & Pages** → **Create** → **Hello World** 模板
+2. 把 [`cf-openai-azure-proxy.js`](./cf-openai-azure-proxy.js) 全部内容粘贴覆盖默认代码 → **Save and Deploy**
+
+**方式 B — wrangler CLI**（可复现、可版本化）
 
 ```bash
 npm i -g wrangler
 wrangler login
 
-# 编辑 wrangler.toml 里的 endpoint
-wrangler secret put AZURE_API_KEY       # 粘贴你的 Azure key
-wrangler secret put CLIENT_API_KEYS     # 粘贴 sk-xxx,sk-yyy
-wrangler secret put MODEL_MAPPING       # 粘贴 JSON 字符串
+# 修改 wrangler.toml 里的 AZURE_OAI_ENDPOINT / AZURE_INFER_ENDPOINT 为你自己的
+wrangler secret put AZURE_API_KEY        # 粘贴 Azure key
+wrangler secret put CLIENT_API_KEYS      # 粘贴 sk-xxx,sk-yyy (自己随便编)
+# 可选：wrangler secret put MODEL_MAPPING
 
 wrangler deploy
 ```
 
-## 环境变量
+### 2. 配置环境变量
+
+进入 Worker → **Settings → Variables and Secrets**，设置：
 
 | 变量 | 类型 | 必填 | 说明 |
 |---|---|---|---|
-| `AZURE_API_KEY` | Secret | ✅ | Azure Foundry 密钥（两个资源共用） |
-| `AZURE_OAI_ENDPOINT` | Var | ✅ | Azure OpenAI 资源根 URL，例如 `https://yoyo.cognitiveservices.azure.com` |
-| `AZURE_INFER_ENDPOINT` | Var | 用到 Grok/DeepSeek 等才必填 | 例如 `https://waytoagi.services.ai.azure.com` |
-| `AZURE_OAI_API_VERSION` | Var | ⬜ | 默认 `2025-04-01-preview` |
-| `AZURE_INFER_API_VERSION` | Var | ⬜ | 默认 `2024-05-01-preview` |
-| `MODEL_MAPPING` | Var/Secret | ⬜ | JSON 字符串；不填则用代码内置默认映射 |
-| `CLIENT_API_KEYS` | Secret | ⬜ | 逗号分隔的客户端 key；不填则透传客户端 Authorization 直连 Azure |
+| `AZURE_API_KEY` | Secret | ✅ | Azure Foundry 密钥 |
+| `AZURE_OAI_ENDPOINT` | Text | ✅ | 例 `https://yoyo.cognitiveservices.azure.com` |
+| `AZURE_INFER_ENDPOINT` | Text | 用 Grok/DeepSeek 等才必填 | 例 `https://waytoagi.services.ai.azure.com` |
+| `CLIENT_API_KEYS` | Secret | 推荐 | `sk-xxx,sk-yyy`（不设则客户端可直连 Azure key） |
+| `AZURE_OAI_API_VERSION` | Text | ⬜ | 默认 `2025-04-01-preview` |
+| `AZURE_INFER_API_VERSION` | Text | ⬜ | 默认 `2024-05-01-preview` |
+| `MODEL_MAPPING` | Secret/Text | ⬜ | JSON；不填用代码内置映射 |
 
-### `MODEL_MAPPING` 示例
+### 3. 客户端接入
+
+在任意支持 OpenAI 的软件里填：
+
+- **Base URL** / **API 地址**：`https://<你的worker>.workers.dev/v1`
+- **API Key**：`CLIENT_API_KEYS` 里你自己设的某个 `sk-xxx`
+
+### 4. 测试一下
+
+```bash
+curl https://<你的worker>.workers.dev/v1/chat/completions \
+  -H "Authorization: Bearer sk-xxx" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
+```
+
+---
+
+## MODEL_MAPPING 详解
+
+内置默认映射已覆盖常见模型（见 [源码顶部](./cf-openai-azure-proxy.js)）。如果你的 Azure deployment 名字和模型名不一致，或要加新模型，就通过 `MODEL_MAPPING` 环境变量覆盖。
+
+格式：
 
 ```json
 {
-  "gpt-5.4":        { "backend": "oai",   "deployment": "gpt-5.4" },
-  "gpt-4o":         { "backend": "oai",   "deployment": "gpt-4o" },
-  "gpt-image-1.5":  { "backend": "oai",   "deployment": "gpt-image-1.5", "apiVersion": "2024-02-01" },
-  "dall-e-3":       { "backend": "oai",   "deployment": "dall-e-3" },
-  "text-embedding-3-small": { "backend": "oai", "deployment": "text-embedding-3-small" },
-  "whisper-1":      { "backend": "oai",   "deployment": "whisper" },
-
-  "grok-4-20":      { "backend": "infer", "deployment": "grok-4-20" },
-  "deepseek-r1":    { "backend": "infer", "deployment": "DeepSeek-R1" },
-  "deepseek-v3":    { "backend": "infer", "deployment": "DeepSeek-V3" }
+  "客户端看到的模型名": {
+    "backend": "oai" 或 "infer",
+    "deployment": "Azure 里的 deployment 名",
+    "apiVersion": "可选，覆盖这个模型专用的 api-version"
+  }
 }
 ```
 
-字段说明：
-- `backend`：`oai` 走 `AZURE_OAI_ENDPOINT`（支持 chat/completions + responses + images + embeddings + audio）；`infer` 走 `AZURE_INFER_ENDPOINT`（仅支持 chat/completions + embeddings）
-- `deployment`：你在 Azure Foundry 里创建 deployment 时填的名字
-- `apiVersion`：可选，覆盖这个模型专用的 api-version（比如 `gpt-image-1.5` 用 `2024-02-01`）
+完整示例：
 
-## 客户端接入
+```json
+{
+  "gpt-5.4":                { "backend":"oai",   "deployment":"gpt-5.4" },
+  "gpt-4o":                 { "backend":"oai",   "deployment":"gpt-4o" },
+  "gpt-4o-mini":            { "backend":"oai",   "deployment":"gpt-4o-mini" },
+  "o1":                     { "backend":"oai",   "deployment":"o1" },
+  "o3-mini":                { "backend":"oai",   "deployment":"o3-mini" },
+  "gpt-image-1":            { "backend":"oai",   "deployment":"gpt-image-1",   "apiVersion":"2024-02-01" },
+  "gpt-image-1.5":          { "backend":"oai",   "deployment":"gpt-image-1.5", "apiVersion":"2024-02-01" },
+  "dall-e-3":               { "backend":"oai",   "deployment":"dall-e-3" },
+  "text-embedding-3-small": { "backend":"oai",   "deployment":"text-embedding-3-small" },
+  "text-embedding-3-large": { "backend":"oai",   "deployment":"text-embedding-3-large" },
+  "whisper-1":              { "backend":"oai",   "deployment":"whisper-1" },
+  "tts-1":                  { "backend":"oai",   "deployment":"tts-1" },
+  "grok-4-20":              { "backend":"infer", "deployment":"grok-4-20" },
+  "grok-3":                 { "backend":"infer", "deployment":"grok-3" },
+  "deepseek-r1":            { "backend":"infer", "deployment":"deepseek-r1" },
+  "deepseek-v3":            { "backend":"infer", "deployment":"deepseek-v3" },
+  "llama-3.3-70b":          { "backend":"infer", "deployment":"llama-3.3-70b" }
+}
+```
 
-在任何支持 OpenAI API 的软件里：
+**backend 说明**：
+- `oai` — 走 `AZURE_OAI_ENDPOINT`，支持 chat/completions + responses + images + embeddings + audio
+- `infer` — 走 `AZURE_INFER_ENDPOINT`，支持 chat/completions + embeddings（Grok / DeepSeek / Llama 等）
 
-- **Base URL**：`https://<your-worker>.workers.dev/v1`
-- **API Key**：`CLIENT_API_KEYS` 里你自己设的那个 `sk-xxx`（如果没开白名单，就填 Azure key）
-
-对于支持 Responses API 的客户端（新版 Cherry Studio、ChatWise、OpenAI SDK ≥ 1.x 的 responses 调用），同一个 base URL 即可，`model` 填 `gpt-5.4` 这种，走的是 `/v1/responses`。
+---
 
 ## 请求路由表
 
-| 客户端请求 | Model 在 mapping 的 backend | 上游 URL |
+| 客户端请求 | backend | 上游 URL |
 |---|---|---|
 | `POST /v1/chat/completions` | `oai` | `{OAI}/openai/deployments/{depl}/chat/completions` |
 | `POST /v1/chat/completions` | `infer` | `{INFER}/models/chat/completions` |
 | `POST /v1/responses` | `oai` | `{OAI}/openai/responses` |
+| `POST /v1/completions` | `oai` | `{OAI}/openai/deployments/{depl}/completions` |
+| `POST /v1/embeddings` | `oai` / `infer` | 同上两种形态之一 |
 | `POST /v1/images/generations` | `oai` | `{OAI}/openai/deployments/{depl}/images/generations` |
-| `POST /v1/embeddings` | `oai` / `infer` | 同上两种之一 |
-| `POST /v1/audio/*` | `oai` | `{OAI}/openai/deployments/{depl}/audio/*`（multipart 透传） |
+| `POST /v1/images/edits` | `oai` | 同上（multipart 透传） |
+| `POST /v1/audio/speech` | `oai` | `{OAI}/openai/deployments/{depl}/audio/speech` |
+| `POST /v1/audio/transcriptions` | `oai` | 同上（multipart 透传） |
+| `POST /v1/audio/translations` | `oai` | 同上（multipart 透传） |
 | `GET /v1/models` | — | 本地从 mapping 生成 |
+
+---
+
+## FAQ / 常见问题
+
+**Q：需要服务器吗？**
+不需要。Cloudflare Workers 是 Serverless，免费额度 10 万请求/天，个人使用绰绰有余。
+
+**Q：`404 Deployment Not Found`？**
+`MODEL_MAPPING` 里的 `deployment` 和 Azure Foundry 控制台里的实际 deployment 名字不一致。到 Foundry → **Deployments** 页核对名字。
+
+**Q：`/v1/responses` 报 404？**
+你的 Azure OpenAI 资源没开 Next-gen v1 API 功能。去 Azure Portal → OpenAI 资源 → **Features** 里开启。
+
+**Q：`gpt-image-1.5` 报 `Unsupported api-version`？**
+gpt-image 系列需要特定 api-version，已在默认 mapping 里设 `"apiVersion":"2024-02-01"`。如果你在 Foundry 里看到的是别的版本，就在 `MODEL_MAPPING` 里覆盖。
+
+**Q：两个 Azure 资源 key 不同怎么办？**
+当前版本共用一个 `AZURE_API_KEY`。如果需要两个 key，改一下代码里 `doFetch` 的 key 来源（按 backend 分）即可。
+
+**Q：想让客户端软件发现所有可用模型？**
+大多数软件会请求 `/v1/models`。代理会自动从 `MODEL_MAPPING` 生成列表，客户端可直接看到。
+
+**Q：流式响应不工作？**
+Cloudflare Workers 原生支持 SSE 透传。如果客户端收不到流，检查：① 客户端是否真的发了 `"stream":true`；② Worker 前是否有自定义域名 + CDN 缓存（应关闭该路径的缓存）。
+
+**Q：代理会存请求日志吗？**
+代码本身不存。Cloudflare Workers 的 observability 面板可以看到实时日志（已在 `wrangler.toml` 开启）。
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ OpenAI-compatible client
 | `ALLOWED_ORIGINS` | 否 | 逗号分隔，仅允许这些浏览器来源通过 CORS 访问，例如 `https://chat.example.com` |
 | `AZURE_OAI_API_VERSION` | 否 | 默认 `2025-04-01-preview` |
 | `AZURE_INFER_API_VERSION` | 否 | 默认 `2024-05-01-preview` |
-| `UPSTREAM_TIMEOUT_MS` | 否 | 上游 Azure 请求超时，默认 `30000` |
+| `UPSTREAM_TIMEOUT_MS` | 否 | 上游 Azure 请求超时（毫秒），默认 `120000`。控制的是等待首字节的时间，流式返回开始后不受此限 |
 | `MODEL_MAPPING` | 否 | JSON 字符串；不填时使用代码内置默认映射 |
 
 说明：
@@ -222,7 +222,7 @@ AZURE_INFER_ENDPOINT    = "https://your-project.services.ai.azure.com"
 AZURE_OAI_API_VERSION   = "2025-04-01-preview"
 AZURE_INFER_API_VERSION = "2024-05-01-preview"
 ALLOWED_ORIGINS         = "https://chat.example.com"
-UPSTREAM_TIMEOUT_MS     = "30000"
+UPSTREAM_TIMEOUT_MS     = "120000"
 ```
 
 敏感信息使用 secret：

--- a/README.md
+++ b/README.md
@@ -95,15 +95,19 @@ OpenAI-compatible client
 | `AZURE_OAI_ENDPOINT` | 使用 Azure OpenAI 时必填 | 例如 `https://your-resource.cognitiveservices.azure.com` |
 | `AZURE_INFER_ENDPOINT` | 使用 Azure AI Model Inference 时必填 | 例如 `https://your-project.services.ai.azure.com` |
 | `CLIENT_API_KEYS` | 推荐 | 逗号分隔，作为客户端访问你这个代理时使用的 key |
+| `ALLOWED_ORIGINS` | 否 | 逗号分隔，仅允许这些浏览器来源通过 CORS 访问，例如 `https://chat.example.com` |
 | `AZURE_OAI_API_VERSION` | 否 | 默认 `2025-04-01-preview` |
 | `AZURE_INFER_API_VERSION` | 否 | 默认 `2024-05-01-preview` |
+| `UPSTREAM_TIMEOUT_MS` | 否 | 上游 Azure 请求超时，默认 `30000` |
 | `MODEL_MAPPING` | 否 | JSON 字符串；不填时使用代码内置默认映射 |
 
 说明：
 
 - 如果设置了 `CLIENT_API_KEYS`，客户端必须用其中某个 key 访问 Worker
+- 如果设置了 `CLIENT_API_KEYS`，也必须同时设置 `AZURE_API_KEY`，避免把客户端 key 错发给 Azure 上游
 - 如果没有设置 `CLIENT_API_KEYS`，Worker 会放行客户端请求
-- 如果同时也没有设置 `AZURE_API_KEY`，则会尝试把客户端 `Authorization: Bearer ...` 当作 Azure key 继续透传
+- 如果没有设置 `CLIENT_API_KEYS` 且也没有设置 `AZURE_API_KEY`，则会尝试把客户端 `Authorization: Bearer ...` 当作 Azure key 继续透传
+- 如果设置了 `ALLOWED_ORIGINS`，只有这些 Origin 的浏览器请求会拿到 CORS 许可；非浏览器客户端不受影响
 
 ## MODEL_MAPPING 格式
 
@@ -217,6 +221,8 @@ AZURE_OAI_ENDPOINT      = "https://your-resource.cognitiveservices.azure.com"
 AZURE_INFER_ENDPOINT    = "https://your-project.services.ai.azure.com"
 AZURE_OAI_API_VERSION   = "2025-04-01-preview"
 AZURE_INFER_API_VERSION = "2024-05-01-preview"
+ALLOWED_ORIGINS         = "https://chat.example.com"
+UPSTREAM_TIMEOUT_MS     = "30000"
 ```
 
 敏感信息使用 secret：
@@ -249,8 +255,9 @@ wrangler deploy
 - 手动部署和 Wrangler 部署的运行效果是一样的，区别主要在发布方式
 - `GET /v1/models` 返回的是映射表里的模型列表，不是 Azure 自动探测结果
 - 只有配置了相应 endpoint 和 deployment 的模型才能真正调用成功
+- 代理默认只透传一小部分安全响应头，不会把 Azure 的 `x-ms-*`、`apim-*` 等内部头原样暴露给客户端
 - 本项目默认只做协议转换和透传，不做重试、缓存、配额、审计或多租户管理
-- 仓库也提供 Docker 镜像，主要用于本地运行 `wrangler dev --local`，不是 Cloudflare 线上部署的必需项
+- 仓库也提供 Docker 镜像，但它运行的是 `wrangler dev --local`，定位是本地调试，不建议当生产部署方式使用
 
 ## 主要文件
 

--- a/README.md
+++ b/README.md
@@ -3,173 +3,94 @@
 <a href="./README_en.md">English</a> |
 <a href="./README.md">中文</a>
 
-> 跑在 **Cloudflare Workers** 上的代理，把 **OpenAI 兼容接口** 转成 **Azure AI Foundry** 的请求。让所有支持 OpenAI 的客户端软件都能直接用你的 Azure 模型。
+> 大多数 OpenAI 客户端不支持 Azure OpenAI / Azure AI Foundry，但 Azure 的申请和绑卡都非常简单，并且还提供了免费的额度。此脚本使用免费的 Cloudflare Worker 作为代理，使得支持 OpenAI 的客户端可以直接使用 Azure AI Foundry 上的各种模型（包括 OpenAI 系、Grok、DeepSeek、Llama 等）。
 
-## 它能做什么
+### 支持模型:
+- GPT 系列（GPT-4o、GPT-5.4、o1、o3 等）
+- 图像生成（DALL-E-3、gpt-image-1、gpt-image-1.5）
+- Embeddings（text-embedding-3-small / large）
+- 语音（Whisper、TTS）
+- Grok 系列（通过 Azure AI Model Inference）
+- DeepSeek / Llama 等第三方模型（通过 Azure AI Model Inference）
 
-Azure AI Foundry 暴露的是**三种互不相同**的 API：经典 Azure OpenAI、新版 Responses API、Azure AI Model Inference（跑 Grok / DeepSeek / Llama 等非 OpenAI 模型）。
+模型子类添加非常容易, 参考下面的使用说明。
 
-这个代理把它们统一到 OpenAI 的 `/v1/*` 规范，任何 OpenAI 客户端（NextChat、LobeChat、Cherry Studio、ChatBox、Zed、Cursor、VS Code Copilot 替代插件等）都能直接用。
+### 项目说明:
+- 我没有服务器可以使用吗?
+    - 这段脚本跑在 Cloudflare Worker, 不需要服务器, 不需要绑卡, 每天 10W 次请求 免费
+- 我没有自己的域名可以使用吗?
+    - 也可以, 参考: https://github.com/haibbo/cf-openai-azure-proxy/issues/3
+- 同时支持哪些 Azure 接口形态？
+    - 经典 Azure OpenAI（`/openai/deployments/{name}/*`）
+    - Responses API（`/openai/responses`，对应客户端的 `/v1/responses`）
+    - Azure AI Model Inference（`/models/*`，跑 Grok/DeepSeek/Llama 等非 OpenAI 模型）
+- 一个 Worker 能不能同时代理多个 Azure 资源？
+    - 可以。本项目设计成 `AZURE_OAI_ENDPOINT`（OpenAI 资源）+ `AZURE_INFER_ENDPOINT`（AI Foundry 第三方模型资源）并存
+- 流式响应支持吗？
+    - 支持。SSE 原生透传，无人为延迟
+- 项目也支持 Docker 部署（基于 wrangler）
 
-## 特性
+### 部署
+代理 OpenAI 的请求到 Azure AI Foundry，代码部署步骤：
 
-- ✅ `/v1/chat/completions` — 自动路由到经典 chat（GPT-4o、o1、gpt-5.4…）或 Model Inference（Grok、DeepSeek、Llama…）
-- ✅ `/v1/responses` — Azure OpenAI Responses API（推理模型的新调用形态）
-- ✅ `/v1/embeddings` / `/v1/images/generations` / `/v1/audio/{speech,transcriptions,translations}` / `/v1/images/edits`
-- ✅ `/v1/models` — 自动从 mapping 生成列表
-- ✅ 客户端 API Key 白名单，Azure 密钥不暴露给客户端
-- ✅ SSE 流式响应原生透传（无降速）
-- ✅ 同一个 Worker 同时代理**两个 Azure 资源**（OpenAI 资源 + Model Inference 资源）
+1. 注册并登录到 Cloudflare 账户
+2. 创建一个新的 Cloudflare Worker
+3. 将 [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js) 复制并粘贴到 Cloudflare Worker 编辑器中
+4. 通过环境变量配置 `AZURE_OAI_ENDPOINT`、`AZURE_API_KEY` 等（详见下方"使用说明"）
+5. 保存并部署 Cloudflare Worker
+6. **可选**绑定自定义域名: 在 Worker 详情页 -> Trigger -> Custom Domains 中为这个 Worker 添加一个自定义域名，参考 https://github.com/haibbo/cf-openai-azure-proxy/issues/3
 
----
-
-## 快速开始（5 分钟）
-
-### 1. 在 Cloudflare 部署 Worker
-
-**方式 A — 控制台粘贴**（零依赖，推荐新手）
-
-1. 登录 [Cloudflare](https://dash.cloudflare.com) → **Workers & Pages** → **Create** → **Hello World** 模板
-2. 把 [`cf-openai-azure-proxy.js`](./cf-openai-azure-proxy.js) 全部内容粘贴覆盖默认代码 → **Save and Deploy**
-
-**方式 B — wrangler CLI**（可复现、可版本化）
+也可以用 wrangler CLI 部署：
 
 ```bash
 npm i -g wrangler
 wrangler login
-
-# 修改 wrangler.toml 里的 AZURE_OAI_ENDPOINT / AZURE_INFER_ENDPOINT 为你自己的
-wrangler secret put AZURE_API_KEY        # 粘贴 Azure key
-wrangler secret put CLIENT_API_KEYS      # 粘贴 sk-xxx,sk-yyy (自己随便编)
-# 可选：wrangler secret put MODEL_MAPPING
-
+wrangler secret put AZURE_API_KEY
+wrangler secret put CLIENT_API_KEYS
 wrangler deploy
 ```
 
-### 2. 配置环境变量
+### 使用说明
 
-进入 Worker → **Settings → Variables and Secrets**，设置：
+先得到 Azure 资源名和各个 deployment 名, 登录到 Azure AI Foundry 后台查看。
 
-| 变量 | 类型 | 必填 | 说明 |
-|---|---|---|---|
-| `AZURE_API_KEY` | Secret | ✅ | Azure Foundry 密钥 |
-| `AZURE_OAI_ENDPOINT` | Text | ✅ | 例 `https://yoyo.cognitiveservices.azure.com` |
-| `AZURE_INFER_ENDPOINT` | Text | 用 Grok/DeepSeek 等才必填 | 例 `https://waytoagi.services.ai.azure.com` |
-| `CLIENT_API_KEYS` | Secret | 推荐 | `sk-xxx,sk-yyy`（不设则客户端可直连 Azure key） |
-| `AZURE_OAI_API_VERSION` | Text | ⬜ | 默认 `2025-04-01-preview` |
-| `AZURE_INFER_API_VERSION` | Text | ⬜ | 默认 `2024-05-01-preview` |
-| `MODEL_MAPPING` | Secret/Text | ⬜ | JSON；不填用代码内置映射 |
+#### 环境变量列表
 
-### 3. 客户端接入
-
-在任意支持 OpenAI 的软件里填：
-
-- **Base URL** / **API 地址**：`https://<你的worker>.workers.dev/v1`
-- **API Key**：`CLIENT_API_KEYS` 里你自己设的某个 `sk-xxx`
-
-### 4. 测试一下
-
-```bash
-curl https://<你的worker>.workers.dev/v1/chat/completions \
-  -H "Authorization: Bearer sk-xxx" \
-  -H "Content-Type: application/json" \
-  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
-```
-
----
-
-## MODEL_MAPPING 详解
-
-内置默认映射已覆盖常见模型（见 [源码顶部](./cf-openai-azure-proxy.js)）。如果你的 Azure deployment 名字和模型名不一致，或要加新模型，就通过 `MODEL_MAPPING` 环境变量覆盖。
-
-格式：
-
-```json
-{
-  "客户端看到的模型名": {
-    "backend": "oai" 或 "infer",
-    "deployment": "Azure 里的 deployment 名",
-    "apiVersion": "可选，覆盖这个模型专用的 api-version"
-  }
-}
-```
-
-完整示例：
-
-```json
-{
-  "gpt-5.4":                { "backend":"oai",   "deployment":"gpt-5.4" },
-  "gpt-4o":                 { "backend":"oai",   "deployment":"gpt-4o" },
-  "gpt-4o-mini":            { "backend":"oai",   "deployment":"gpt-4o-mini" },
-  "o1":                     { "backend":"oai",   "deployment":"o1" },
-  "o3-mini":                { "backend":"oai",   "deployment":"o3-mini" },
-  "gpt-image-1":            { "backend":"oai",   "deployment":"gpt-image-1",   "apiVersion":"2024-02-01" },
-  "gpt-image-1.5":          { "backend":"oai",   "deployment":"gpt-image-1.5", "apiVersion":"2024-02-01" },
-  "dall-e-3":               { "backend":"oai",   "deployment":"dall-e-3" },
-  "text-embedding-3-small": { "backend":"oai",   "deployment":"text-embedding-3-small" },
-  "text-embedding-3-large": { "backend":"oai",   "deployment":"text-embedding-3-large" },
-  "whisper-1":              { "backend":"oai",   "deployment":"whisper-1" },
-  "tts-1":                  { "backend":"oai",   "deployment":"tts-1" },
-  "grok-4-20":              { "backend":"infer", "deployment":"grok-4-20" },
-  "grok-3":                 { "backend":"infer", "deployment":"grok-3" },
-  "deepseek-r1":            { "backend":"infer", "deployment":"deepseek-r1" },
-  "deepseek-v3":            { "backend":"infer", "deployment":"deepseek-v3" },
-  "llama-3.3-70b":          { "backend":"infer", "deployment":"llama-3.3-70b" }
-}
-```
-
-**backend 说明**：
-- `oai` — 走 `AZURE_OAI_ENDPOINT`，支持 chat/completions + responses + images + embeddings + audio
-- `infer` — 走 `AZURE_INFER_ENDPOINT`，支持 chat/completions + embeddings（Grok / DeepSeek / Llama 等）
-
----
-
-## 请求路由表
-
-| 客户端请求 | backend | 上游 URL |
+| 变量 | 必填 | 说明 |
 |---|---|---|
-| `POST /v1/chat/completions` | `oai` | `{OAI}/openai/deployments/{depl}/chat/completions` |
-| `POST /v1/chat/completions` | `infer` | `{INFER}/models/chat/completions` |
-| `POST /v1/responses` | `oai` | `{OAI}/openai/responses` |
-| `POST /v1/completions` | `oai` | `{OAI}/openai/deployments/{depl}/completions` |
-| `POST /v1/embeddings` | `oai` / `infer` | 同上两种形态之一 |
-| `POST /v1/images/generations` | `oai` | `{OAI}/openai/deployments/{depl}/images/generations` |
-| `POST /v1/images/edits` | `oai` | 同上（multipart 透传） |
-| `POST /v1/audio/speech` | `oai` | `{OAI}/openai/deployments/{depl}/audio/speech` |
-| `POST /v1/audio/transcriptions` | `oai` | 同上（multipart 透传） |
-| `POST /v1/audio/translations` | `oai` | 同上（multipart 透传） |
-| `GET /v1/models` | — | 本地从 mapping 生成 |
+| `AZURE_API_KEY` | ✅ | Azure 密钥（Secret） |
+| `AZURE_OAI_ENDPOINT` | ✅ | 例 `https://yoyo.cognitiveservices.azure.com` |
+| `AZURE_INFER_ENDPOINT` | 用 Grok/DeepSeek 才要 | 例 `https://waytoagi.services.ai.azure.com` |
+| `CLIENT_API_KEYS` | 推荐 | 逗号分隔，例 `sk-mykey1,sk-mykey2` |
+| `AZURE_OAI_API_VERSION` | ⬜ | 默认 `2025-04-01-preview` |
+| `AZURE_INFER_API_VERSION` | ⬜ | 默认 `2024-05-01-preview` |
+| `MODEL_MAPPING` | ⬜ | JSON 字符串，不填用代码内置默认映射 |
 
----
+<img width="777" src="https://user-images.githubusercontent.com/1295315/233384224-aa6581f0-26a4-49cf-ae25-4dfb466143da.png" alt="env" />
 
-## FAQ / 常见问题
+#### 这里有两种做法:
 
-**Q：需要服务器吗？**
-不需要。Cloudflare Workers 是 Serverless，免费额度 10 万请求/天，个人使用绰绰有余。
+- 直接修改代码顶部 `DEFAULT_MAPPING` 的值, 如:
 
-**Q：`404 Deployment Not Found`？**
-`MODEL_MAPPING` 里的 `deployment` 和 Azure Foundry 控制台里的实际 deployment 名字不一致。到 Foundry → **Deployments** 页核对名字。
+```js
+const DEFAULT_MAPPING = {
+  "gpt-4o":       { backend: "oai",   deployment: "gpt-4o" },
+  "gpt-5.4":      { backend: "oai",   deployment: "gpt-5.4" },
+  "dall-e-3":     { backend: "oai",   deployment: "dall-e-3" },
+  "grok-4-20":    { backend: "infer", deployment: "grok-4-20" },
+  "deepseek-r1":  { backend: "infer", deployment: "deepseek-r1" },
+};
+// 其他的 map 规则直接按这样的格式续写即可
+// backend: "oai" 走 Azure OpenAI，"infer" 走 Azure AI Model Inference
+```
 
-**Q：`/v1/responses` 报 404？**
-你的 Azure OpenAI 资源没开 Next-gen v1 API 功能。去 Azure Portal → OpenAI 资源 → **Features** 里开启。
+- 或者通过 cloudflare worker 控制台, 进入 Workers script > Settings > Variables and Secrets, 把整个 JSON 作为 `MODEL_MAPPING` 变量填进去。
 
-**Q：`gpt-image-1.5` 报 `Unsupported api-version`？**
-gpt-image 系列需要特定 api-version，已在默认 mapping 里设 `"apiVersion":"2024-02-01"`。如果你在 Foundry 里看到的是别的版本，就在 `MODEL_MAPPING` 里覆盖。
+### 客户端
+以 OpenCat 为例: 自定义 API 域名填写绑定的域名（加 `/v1` 后缀），API Key 填 `CLIENT_API_KEYS` 里你自己设的某个 `sk-xxx`：
 
-**Q：两个 Azure 资源 key 不同怎么办？**
-当前版本共用一个 `AZURE_API_KEY`。如果需要两个 key，改一下代码里 `doFetch` 的 key 来源（按 backend 分）即可。
+<img width="339" src="https://user-images.githubusercontent.com/1295315/229820705-ab2ad1d1-8795-4670-97b4-16a0f9fdebba.png" alt="opencat" />
 
-**Q：想让客户端软件发现所有可用模型？**
-大多数软件会请求 `/v1/models`。代理会自动从 `MODEL_MAPPING` 生成列表，客户端可直接看到。
+对于支持 Responses API 的新版客户端（Cherry Studio、ChatWise 等），同样填上面的 base URL 即可，代理会自动把 `/v1/responses` 转给 Azure。
 
-**Q：流式响应不工作？**
-Cloudflare Workers 原生支持 SSE 透传。如果客户端收不到流，检查：① 客户端是否真的发了 `"stream":true`；② Worker 前是否有自定义域名 + CDN 缓存（应关闭该路径的缓存）。
-
-**Q：代理会存请求日志吗？**
-代码本身不存。Cloudflare Workers 的 observability 面板可以看到实时日志（已在 `wrangler.toml` 开启）。
-
----
-
-## License
-
-MIT
+我已经尝试了多种客户端, 如果遇到其他客户端有问题, 欢迎创建 issue。

--- a/README_en.md
+++ b/README_en.md
@@ -138,16 +138,73 @@ Rules:
 
 ## Deployment
 
-The recommended deployment path is Cloudflare Workers with Wrangler.
+The recommended starting point is manual deployment in the Cloudflare Dashboard because it is the most obvious path for first-time setup. `Wrangler` is optional and is better for repeat updates, versioned config, and local development.
 
-### 1. Install and log in
+### Option 1: Manual Deployment in the Cloudflare Dashboard
+
+#### 1. Create a Worker
+
+- Sign in to the Cloudflare Dashboard
+- Open Workers & Pages
+- Create a new Worker
+
+#### 2. Paste the script
+
+Copy the full contents of [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js) into the Cloudflare Worker editor and replace the default sample code.
+
+#### 3. Configure Variables and Secrets
+
+In the Worker Settings / Variables page, add:
+
+- regular variables for non-sensitive values
+  - `AZURE_OAI_ENDPOINT`
+  - `AZURE_INFER_ENDPOINT`
+  - `AZURE_OAI_API_VERSION`
+  - `AZURE_INFER_API_VERSION`
+- secrets for sensitive values
+  - `AZURE_API_KEY`
+  - `CLIENT_API_KEYS`
+  - `MODEL_MAPPING`
+
+You can start with the minimum required set:
+
+- `AZURE_API_KEY`
+- `AZURE_OAI_ENDPOINT` or `AZURE_INFER_ENDPOINT`
+- `CLIENT_API_KEYS` (recommended)
+
+Add `MODEL_MAPPING` only if you want to override the built-in mapping.
+
+#### 4. Deploy and use the Worker URL
+
+Save and deploy the Worker. Cloudflare will give you a Worker URL.
+
+Use this as the base URL in your OpenAI-compatible client:
+
+```text
+https://your-worker.your-subdomain.workers.dev/v1
+```
+
+If you have your own domain, you can also bind a custom domain or route in the Worker settings and use `https://your-domain/v1` instead.
+
+### Option 2: Deploy with Wrangler CLI
+
+`Wrangler` is not required. It simply turns the "paste code in the dashboard, fill in variables, click deploy" flow into a CLI workflow that is easier to repeat.
+
+In this repository:
+
+- [wrangler.toml](./wrangler.toml) sets the entrypoint with `main = "cf-openai-azure-proxy.js"`
+- `wrangler deploy` uploads [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js) as the Worker
+- non-secret values from `[vars]` are included automatically
+- sensitive values such as `AZURE_API_KEY`, `CLIENT_API_KEYS`, and `MODEL_MAPPING` should still be stored as secrets
+
+#### 1. Install and log in
 
 ```bash
 npm i -g wrangler
 wrangler login
 ```
 
-### 2. Configure variables
+#### 2. Configure variables
 
 Use `[vars]` in `wrangler.toml` for non-secret values, for example:
 
@@ -167,7 +224,7 @@ wrangler secret put CLIENT_API_KEYS
 wrangler secret put MODEL_MAPPING
 ```
 
-### 3. Deploy
+#### 3. Deploy
 
 ```bash
 wrangler deploy
@@ -186,10 +243,11 @@ Clients that support the newer Responses API can use the same base URL; the prox
 
 ## Notes
 
+- manual deployment and Wrangler deployment behave the same after release; the main difference is how you publish updates
 - `GET /v1/models` reflects the configured mapping, not Azure auto-discovery
 - a model only works if the corresponding endpoint and deployment are actually configured in Azure
 - this project intentionally stays small: it does not implement retries, caching, quotas, auditing, or multi-tenant management
-- the repository also ships a Docker image, mainly for running `wrangler dev --local`; for actual Cloudflare deployment, Wrangler is still the recommended path
+- the repository also ships a Docker image, mainly for running `wrangler dev --local`; it is not required for Cloudflare production deployment
 
 ## Main Files
 

--- a/README_en.md
+++ b/README_en.md
@@ -95,7 +95,7 @@ Configure these in Cloudflare Workers Variables / Secrets:
 | `ALLOWED_ORIGINS` | No | Comma-separated browser origins allowed by CORS, for example `https://chat.example.com` |
 | `AZURE_OAI_API_VERSION` | No | Defaults to `2025-04-01-preview` |
 | `AZURE_INFER_API_VERSION` | No | Defaults to `2024-05-01-preview` |
-| `UPSTREAM_TIMEOUT_MS` | No | Timeout for Azure upstream requests, defaults to `30000` |
+| `UPSTREAM_TIMEOUT_MS` | No | Timeout for Azure upstream requests in milliseconds, defaults to `120000`. Bounds time-to-first-byte only — streaming bodies are not cut off once they start |
 | `MODEL_MAPPING` | No | JSON string; falls back to the built-in default mapping |
 
 Notes:
@@ -219,7 +219,7 @@ AZURE_INFER_ENDPOINT    = "https://your-project.services.ai.azure.com"
 AZURE_OAI_API_VERSION   = "2025-04-01-preview"
 AZURE_INFER_API_VERSION = "2024-05-01-preview"
 ALLOWED_ORIGINS         = "https://chat.example.com"
-UPSTREAM_TIMEOUT_MS     = "30000"
+UPSTREAM_TIMEOUT_MS     = "120000"
 ```
 
 Use secrets for sensitive values:

--- a/README_en.md
+++ b/README_en.md
@@ -3,47 +3,200 @@
 <a href="./README_en.md">English</a> |
 <a href="./README.md">中文</a>
 
-> Most OpenAI clients do not support Azure OpenAI Service, but the application for Azure OpenAI Service is very simple, and it also provides free quotas. This script uses a free Cloudflare Worker as a proxy, allowing OpenAI-supported clients to directly use Azure OpenAI Service.
+> An OpenAI-compatible proxy for Cloudflare Workers. It accepts `/v1/*` requests from OpenAI-style clients and forwards them to Azure OpenAI or Azure AI Foundry using the upstream shape each backend expects.
 
-This script proxies requests to Azure OpenAI Service for OpenAI clients. The code deployment steps are as follows:
+## What This Project Does
 
-Register and log in to your Cloudflare account.
-- Create a new Cloudflare Worker.
-- Copy and paste cf-openai-azure-proxy.js into the Cloudflare Worker editor.
-- Adjust the values of **resourceName** and deployment **mapper** by either direct modification or using environment variables..
-- Save and deploy the Cloudflare Worker.
-- https://github.com/haibbo/cf-openai-azure-proxy/issues/3 Optional: Bind a custom domain name: Add a custom domain name for this worker in the Worker details page -> Trigger -> Custom Domains.
+Many desktop and mobile clients only know how to talk to the OpenAI API. This project acts as a thin compatibility layer:
 
-## Instructions
-First obtain the resourceName and deployment mapper, and log in to the Azure portal:
+- clients keep calling `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`, and similar OpenAI-style routes
+- the Worker looks up the requested `model`
+- the request is then forwarded to Azure OpenAI or Azure AI Model Inference
 
-<img width="777" src="https://user-images.githubusercontent.com/1295315/233124125-1ea95665-ffab-4b5c-a7ba-26f31f1bb0b3.png" alt="env" />
+This is a stateless proxy. It is not a chatbot app, billing system, admin panel, or database-backed service.
 
-#### There are two ways to do this:
-- Directly modify their values, such as:
-```js
-// The name of your Azure OpenAI Resource.
-const resourceName="codegpt"
+## Current Capabilities
 
-  const mapper:any = {
-    'gpt-3.5-turbo': 'gpt3',
-    'gpt-4': 'gpt4' 
-  };
+- OpenAI-compatible entrypoints
+  - `POST /v1/chat/completions`
+  - `POST /v1/responses`
+  - `POST /v1/completions`
+  - `POST /v1/embeddings`
+  - `POST /v1/images/generations`
+  - `POST /v1/audio/speech`
+  - `POST /v1/audio/transcriptions`
+  - `POST /v1/audio/translations`
+  - `POST /v1/images/edits`
+  - `POST /v1/images/variations`
+  - `GET /v1/models`
+- Azure OpenAI classic deployment routes
+  - `/openai/deployments/{deployment}/*`
+- Azure OpenAI Responses API
+  - `/openai/responses`
+- Azure AI Model Inference routes
+  - `/models/*`
+- Native streaming passthrough
+- Optional client-side allowlist auth via `CLIENT_API_KEYS`
+
+## Supported Model Categories
+
+The built-in default mapping includes examples for:
+
+- GPT family
+  - `gpt-5.4`
+  - `gpt-4o`
+  - `gpt-4o-mini`
+  - `o1`
+  - `o3-mini`
+- Image generation
+  - `gpt-image-1`
+  - `gpt-image-1.5`
+  - `dall-e-3`
+- Embeddings
+  - `text-embedding-3-small`
+  - `text-embedding-3-large`
+- Audio
+  - `whisper-1`
+  - `tts-1`
+- Third-party Azure AI Foundry models
+  - `grok-4-20`
+  - `grok-3`
+  - `deepseek-r1`
+  - `deepseek-v3`
+  - `llama-3.3-70b`
+
+What actually works depends on which deployments exist in your Azure resources and how `MODEL_MAPPING` is configured.
+
+## How It Works
+
+```text
+OpenAI-compatible client
+  -> /v1/chat/completions | /v1/responses | /v1/embeddings | ...
+  -> Cloudflare Worker
+  -> validate Authorization / CLIENT_API_KEYS
+  -> read body.model
+  -> resolve backend + deployment from MODEL_MAPPING
+  -> forward to the right Azure upstream
+     - backend=oai   -> {AZURE_OAI_ENDPOINT}/openai/...
+     - backend=infer -> {AZURE_INFER_ENDPOINT}/models/...
+  -> return the upstream response as-is
 ```
-Other map rules can be continued directly in this format.
-- **OR** go to the Cloudflare Worker console, navigate to Workers script > Settings > Add variable under Environment Variables.
 
-<img width="777" src="https://user-images.githubusercontent.com/1295315/233384224-aa6581f0-26a4-49cf-ae25-4dfb466143da.png" alt="env" />
+## Environment Variables
 
-## Client
-Take OpenCat as an example: fill in the custom API domain name with the domain name bound in step 6:
+Configure these in Cloudflare Workers Variables / Secrets:
 
-<img width="339" src="https://user-images.githubusercontent.com/1295315/229820705-ab2ad1d1-8795-4670-97b4-16a0f9fdebba.png" alt="opencat" />
-I have tried multiple clients. If you encounter problems with other clients, please feel free to create an issue.
+| Variable | Required | Description |
+|---|---|---|
+| `AZURE_API_KEY` | Recommended | Azure API key used by the Worker when calling Azure |
+| `AZURE_OAI_ENDPOINT` | Required for Azure OpenAI | Example: `https://your-resource.cognitiveservices.azure.com` |
+| `AZURE_INFER_ENDPOINT` | Required for Azure AI Model Inference | Example: `https://your-project.services.ai.azure.com` |
+| `CLIENT_API_KEYS` | Recommended | Comma-separated keys accepted by your proxy |
+| `AZURE_OAI_API_VERSION` | No | Defaults to `2025-04-01-preview` |
+| `AZURE_INFER_API_VERSION` | No | Defaults to `2024-05-01-preview` |
+| `MODEL_MAPPING` | No | JSON string; falls back to the built-in default mapping |
 
-QA:
+Notes:
 
-- Do I need a server to use this?
-  - This script runs on Cloudflare Worker and does not require a server or a bound card. It is free for up to 100,000 requests per day.
-- Do I need my own domain name to use this?
-  - No, it is not necessary. Refer to: https://github.com/haibbo/cf-openai-azure-proxy/issues/3
+- if `CLIENT_API_KEYS` is set, clients must use one of those keys to access the proxy
+- if `CLIENT_API_KEYS` is not set, client auth is skipped
+- if `AZURE_API_KEY` is also not set, the Worker will try to forward the client's `Authorization: Bearer ...` value as the Azure key
+
+## MODEL_MAPPING Format
+
+`MODEL_MAPPING` is a JSON object where each key is the model name seen by the client, and each value tells the Worker which backend and deployment to use.
+
+Example:
+
+```json
+{
+  "gpt-5.4": {
+    "backend": "oai",
+    "deployment": "gpt-5.4"
+  },
+  "gpt-4o": {
+    "backend": "oai",
+    "deployment": "gpt-4o"
+  },
+  "grok-4-20": {
+    "backend": "infer",
+    "deployment": "grok-4-20"
+  },
+  "deepseek-r1": {
+    "backend": "infer",
+    "deployment": "deepseek-r1"
+  }
+}
+```
+
+Rules:
+
+- `backend: "oai"` routes to Azure OpenAI
+- `backend: "infer"` routes to Azure AI Model Inference
+- `deployment` must match the real deployment name in Azure
+- optional `apiVersion` can override the default API version for that entry
+
+## Deployment
+
+The recommended deployment path is Cloudflare Workers with Wrangler.
+
+### 1. Install and log in
+
+```bash
+npm i -g wrangler
+wrangler login
+```
+
+### 2. Configure variables
+
+Use `[vars]` in `wrangler.toml` for non-secret values, for example:
+
+```toml
+[vars]
+AZURE_OAI_ENDPOINT      = "https://your-resource.cognitiveservices.azure.com"
+AZURE_INFER_ENDPOINT    = "https://your-project.services.ai.azure.com"
+AZURE_OAI_API_VERSION   = "2025-04-01-preview"
+AZURE_INFER_API_VERSION = "2024-05-01-preview"
+```
+
+Use secrets for sensitive values:
+
+```bash
+wrangler secret put AZURE_API_KEY
+wrangler secret put CLIENT_API_KEYS
+wrangler secret put MODEL_MAPPING
+```
+
+### 3. Deploy
+
+```bash
+wrangler deploy
+```
+
+After deployment, point your client to `{WORKER_URL}/v1`.
+
+## Client Configuration
+
+For an OpenAI-compatible client:
+
+- Base URL: `https://your-worker.your-subdomain.workers.dev/v1`
+- API Key: one of the keys listed in `CLIENT_API_KEYS`
+
+Clients that support the newer Responses API can use the same base URL; the proxy will translate `/v1/responses` to Azure's `/openai/responses`.
+
+## Notes
+
+- `GET /v1/models` reflects the configured mapping, not Azure auto-discovery
+- a model only works if the corresponding endpoint and deployment are actually configured in Azure
+- this project intentionally stays small: it does not implement retries, caching, quotas, auditing, or multi-tenant management
+- the repository also ships a Docker image, mainly for running `wrangler dev --local`; for actual Cloudflare deployment, Wrangler is still the recommended path
+
+## Main Files
+
+- [cf-openai-azure-proxy.js](./cf-openai-azure-proxy.js): current Worker implementation
+- [wrangler.toml](./wrangler.toml): Worker configuration
+- [cf-openai-palm-proxy.js](./cf-openai-palm-proxy.js): older PaLM proxy script, unrelated to the current Azure-focused implementation
+
+## License
+
+[MIT](./LICENSE)

--- a/README_en.md
+++ b/README_en.md
@@ -92,15 +92,19 @@ Configure these in Cloudflare Workers Variables / Secrets:
 | `AZURE_OAI_ENDPOINT` | Required for Azure OpenAI | Example: `https://your-resource.cognitiveservices.azure.com` |
 | `AZURE_INFER_ENDPOINT` | Required for Azure AI Model Inference | Example: `https://your-project.services.ai.azure.com` |
 | `CLIENT_API_KEYS` | Recommended | Comma-separated keys accepted by your proxy |
+| `ALLOWED_ORIGINS` | No | Comma-separated browser origins allowed by CORS, for example `https://chat.example.com` |
 | `AZURE_OAI_API_VERSION` | No | Defaults to `2025-04-01-preview` |
 | `AZURE_INFER_API_VERSION` | No | Defaults to `2024-05-01-preview` |
+| `UPSTREAM_TIMEOUT_MS` | No | Timeout for Azure upstream requests, defaults to `30000` |
 | `MODEL_MAPPING` | No | JSON string; falls back to the built-in default mapping |
 
 Notes:
 
 - if `CLIENT_API_KEYS` is set, clients must use one of those keys to access the proxy
+- if `CLIENT_API_KEYS` is set, `AZURE_API_KEY` must also be set so client keys are never forwarded upstream by mistake
 - if `CLIENT_API_KEYS` is not set, client auth is skipped
-- if `AZURE_API_KEY` is also not set, the Worker will try to forward the client's `Authorization: Bearer ...` value as the Azure key
+- if `CLIENT_API_KEYS` is not set and `AZURE_API_KEY` is also not set, the Worker will try to forward the client's `Authorization: Bearer ...` value as the Azure key
+- if `ALLOWED_ORIGINS` is set, only those browser origins receive CORS access; non-browser clients are unaffected
 
 ## MODEL_MAPPING Format
 
@@ -214,6 +218,8 @@ AZURE_OAI_ENDPOINT      = "https://your-resource.cognitiveservices.azure.com"
 AZURE_INFER_ENDPOINT    = "https://your-project.services.ai.azure.com"
 AZURE_OAI_API_VERSION   = "2025-04-01-preview"
 AZURE_INFER_API_VERSION = "2024-05-01-preview"
+ALLOWED_ORIGINS         = "https://chat.example.com"
+UPSTREAM_TIMEOUT_MS     = "30000"
 ```
 
 Use secrets for sensitive values:
@@ -246,8 +252,9 @@ Clients that support the newer Responses API can use the same base URL; the prox
 - manual deployment and Wrangler deployment behave the same after release; the main difference is how you publish updates
 - `GET /v1/models` reflects the configured mapping, not Azure auto-discovery
 - a model only works if the corresponding endpoint and deployment are actually configured in Azure
+- the proxy now forwards only a small whitelist of safe response headers instead of exposing Azure-specific `x-ms-*` or `apim-*` headers as-is
 - this project intentionally stays small: it does not implement retries, caching, quotas, auditing, or multi-tenant management
-- the repository also ships a Docker image, mainly for running `wrangler dev --local`; it is not required for Cloudflare production deployment
+- the repository also ships a Docker image, but it runs `wrangler dev --local` and is meant for local debugging rather than production deployment
 
 ## Main Files
 

--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -1,177 +1,271 @@
-// The name of your Azure OpenAI Resource.
-const resourceName=RESOURCE_NAME
+// Cloudflare Workers proxy: OpenAI-compatible -> Azure AI Foundry
+// Supports three upstream shapes:
+//   1. Classic Azure OpenAI   : {OAI}/openai/deployments/{deployment}/{endpoint}?api-version=...
+//   2. Responses API          : {OAI}/openai/responses?api-version=...   (model in body, no deployment in URL)
+//   3. Azure Model Inference  : {INFER}/models/{endpoint}?api-version=... (model in body, no deployment in URL)
+//
+// Required env vars (set in Workers dashboard -> Settings -> Variables):
+//   AZURE_API_KEY            (Secret) Shared key for both resources
+//   AZURE_OAI_ENDPOINT       e.g. https://yoyo.cognitiveservices.azure.com
+//   AZURE_INFER_ENDPOINT     e.g. https://waytoagi.services.ai.azure.com
+//   AZURE_OAI_API_VERSION    default 2025-04-01-preview
+//   AZURE_INFER_API_VERSION  default 2024-05-01-preview
+//   MODEL_MAPPING            JSON string, see DEFAULT_MAPPING below
+//   CLIENT_API_KEYS          comma-separated list, e.g. sk-abc,sk-def (optional but recommended)
 
-// The deployment name you chose when you deployed the model.
-const mapper = {
-    'gpt-3.5-turbo': DEPLOY_NAME_GPT35,
-    'gpt-3.5-turbo-0613': DEPLOY_NAME_GPT35,
-    'gpt-3.5-turbo-1106': DEPLOY_NAME_GPT35,
-    'gpt-3.5-turbo-16k': DEPLOY_NAME_GPT35,
-    'gpt-4': DEPLOY_NAME_GPT4,
-    'gpt-4-0613': DEPLOY_NAME_GPT4,
-    'gpt-4-1106-preview': DEPLOY_NAME_GPT4,
-    'gpt-4-32k': DEPLOY_NAME_GPT4,
-    'dall-e-3': typeof DEPLOY_NAME_DALLE3 !== 'undefined' ? DEPLOY_NAME_DALLE3 : "dalle3",
+const DEFAULT_MAPPING = {
+  // OpenAI-family on yoyo (classic + responses share the same entry;
+  // the proxy picks the upstream path based on which client path was hit)
+  "gpt-5.4":               { backend: "oai",   deployment: "gpt-5.4" },
+  "gpt-4o":                { backend: "oai",   deployment: "gpt-4o" },
+  "gpt-4o-mini":           { backend: "oai",   deployment: "gpt-4o-mini" },
+  "o1":                    { backend: "oai",   deployment: "o1" },
+  "o3-mini":               { backend: "oai",   deployment: "o3-mini" },
+
+  "gpt-image-1":           { backend: "oai",   deployment: "gpt-image-1",   apiVersion: "2024-02-01" },
+  "gpt-image-1.5":         { backend: "oai",   deployment: "gpt-image-1.5", apiVersion: "2024-02-01" },
+  "dall-e-3":              { backend: "oai",   deployment: "dall-e-3" },
+
+  "text-embedding-3-small":{ backend: "oai",   deployment: "text-embedding-3-small" },
+  "text-embedding-3-large":{ backend: "oai",   deployment: "text-embedding-3-large" },
+  "whisper-1":             { backend: "oai",   deployment: "whisper-1" },
+  "tts-1":                 { backend: "oai",   deployment: "tts-1" },
+
+  // Non-OpenAI models on waytoagi (Azure AI Model Inference)
+  "grok-4-20":             { backend: "infer", deployment: "grok-4-20" },
+  "grok-3":                { backend: "infer", deployment: "grok-3" },
+  "deepseek-r1":           { backend: "infer", deployment: "deepseek-r1" },
+  "deepseek-v3":           { backend: "infer", deployment: "deepseek-v3" },
+  "llama-3.3-70b":         { backend: "infer", deployment: "llama-3.3-70b" }
 };
 
-const apiVersion="2023-12-01-preview"
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "*"
+};
 
-addEventListener("fetch", (event) => {
-  event.respondWith(handleRequest(event.request));
-});
+export default {
+  async fetch(request, env) {
+    try {
+      if (request.method === "OPTIONS") {
+        return new Response(null, { headers: CORS_HEADERS });
+      }
 
-async function handleRequest(request) {
-  if (request.method === 'OPTIONS') {
-    return handleOPTIONS(request)
+      const cfg = loadConfig(env);
+      const url = new URL(request.url);
+      let path = url.pathname.replace(/\/+/g, "/");
+      if (path.startsWith("/v1/")) path = path.slice(3);
+
+      // Client auth
+      const authErr = checkClientAuth(request, cfg);
+      if (authErr) return authErr;
+
+      // Routes that don't need model lookup
+      if (path === "/models" && request.method === "GET") {
+        return listModels(cfg);
+      }
+
+      // Multipart routes (audio + image edits) — must not json-parse the body
+      if (path === "/audio/transcriptions" || path === "/audio/translations" ||
+          path === "/images/edits" || path === "/images/variations") {
+        return proxyMultipart(request, path, cfg);
+      }
+
+      // JSON routes
+      if (request.method !== "POST") {
+        return errorResponse(404, "not_found", `No handler for ${request.method} ${path}`);
+      }
+
+      const body = await request.json().catch(() => null);
+      if (!body) return errorResponse(400, "invalid_request_error", "Request body must be valid JSON");
+
+      const modelName = body.model;
+      if (!modelName) return errorResponse(400, "invalid_request_error", "Missing 'model' field in request body");
+
+      const entry = cfg.mapping[modelName];
+      if (!entry) return errorResponse(400, "model_not_found", `Model '${modelName}' is not mapped. Update MODEL_MAPPING env var.`);
+
+      // Route by client path + backend
+      const azureKey = resolveAzureKey(request, cfg);
+      if (path === "/chat/completions") {
+        return proxyChatCompletions(body, entry, cfg, azureKey);
+      }
+      if (path === "/responses") {
+        return proxyResponses(body, entry, cfg, azureKey);
+      }
+      if (path === "/completions") {
+        return proxyClassic(body, entry, cfg, "completions", azureKey);
+      }
+      if (path === "/embeddings") {
+        if (entry.backend === "infer") return proxyInference(body, entry, cfg, "embeddings", azureKey);
+        return proxyClassic(body, entry, cfg, "embeddings", azureKey);
+      }
+      if (path === "/images/generations") {
+        return proxyClassic(body, entry, cfg, "images/generations", azureKey);
+      }
+      if (path === "/audio/speech") {
+        return proxyClassic(body, entry, cfg, "audio/speech", azureKey);
+      }
+
+      return errorResponse(404, "not_found", `Unsupported path: ${url.pathname}`);
+    } catch (e) {
+      return errorResponse(500, "proxy_error", e.message || String(e));
+    }
+  }
+};
+
+function loadConfig(env) {
+  let mapping = DEFAULT_MAPPING;
+  if (env.MODEL_MAPPING) {
+    try {
+      mapping = JSON.parse(env.MODEL_MAPPING);
+    } catch (e) {
+      throw new Error("MODEL_MAPPING is not valid JSON: " + e.message);
+    }
   }
 
-  const url = new URL(request.url);
-  if (url.pathname.startsWith("//")) {
-    url.pathname = url.pathname.replace('/',"")
-  }
-  if (url.pathname === '/v1/chat/completions') {
-    var path="chat/completions"
-  } else if (url.pathname === '/v1/images/generations') {
-    var path="images/generations"
-  } else if (url.pathname === '/v1/completions') {
-    var path="completions"
-  } else if (url.pathname === '/v1/models') {
-    return handleModels(request)
-  } else {
-    return new Response('404 Not Found', { status: 404 })
-  }
+  const clientKeys = (env.CLIENT_API_KEYS || "")
+    .split(",").map(s => s.trim()).filter(Boolean);
 
-  let body;
-  if (request.method === 'POST') {
-    body = await request.json();
+  return {
+    mapping,
+    clientKeys,
+    azureKey: env.AZURE_API_KEY || "",
+    oaiEndpoint: stripTrailingSlash(env.AZURE_OAI_ENDPOINT || ""),
+    inferEndpoint: stripTrailingSlash(env.AZURE_INFER_ENDPOINT || ""),
+    oaiApiVersion: env.AZURE_OAI_API_VERSION || "2025-04-01-preview",
+    inferApiVersion: env.AZURE_INFER_API_VERSION || "2024-05-01-preview"
+  };
+}
+
+function stripTrailingSlash(s) { return s.replace(/\/+$/, ""); }
+
+function checkClientAuth(request, cfg) {
+  // If no CLIENT_API_KEYS configured, allow through (legacy mode: client supplies Azure key).
+  if (cfg.clientKeys.length === 0) return null;
+  const auth = request.headers.get("Authorization") || "";
+  const key = auth.replace(/^Bearer\s+/i, "").trim();
+  if (!key || !cfg.clientKeys.includes(key)) {
+    return errorResponse(401, "invalid_api_key", "Invalid API key");
   }
+  return null;
+}
 
-  const modelName = body?.model;  
-  const deployName = mapper[modelName] || '' 
+function resolveAzureKey(request, cfg) {
+  if (cfg.azureKey) return cfg.azureKey;
+  const auth = request.headers.get("Authorization") || "";
+  return auth.replace(/^Bearer\s+/i, "").trim();
+}
 
-  if (deployName === '') {
-    return new Response('Missing model mapper', {
-        status: 403
-    });
+async function proxyChatCompletions(body, entry, cfg, azureKey) {
+  if (entry.backend === "infer") {
+    return proxyInference(body, entry, cfg, "chat/completions", azureKey);
   }
-  const fetchAPI = `https://${resourceName}.openai.azure.com/openai/deployments/${deployName}/${path}?api-version=${apiVersion}`
+  return proxyClassic(body, entry, cfg, "chat/completions", azureKey);
+}
 
-  const authKey = request.headers.get('Authorization');
-  if (!authKey) {
-    return new Response("Not allowed", {
-      status: 403
-    });
+async function proxyResponses(body, entry, cfg, azureKey) {
+  if (entry.backend !== "oai") {
+    return errorResponse(400, "invalid_request_error",
+      `Model '${body.model}' is on backend '${entry.backend}' which does not support /v1/responses`);
   }
+  const apiVersion = entry.apiVersion || cfg.oaiApiVersion;
+  const upstream = `${cfg.oaiEndpoint}/openai/responses?api-version=${apiVersion}`;
+  const upstreamBody = { ...body, model: entry.deployment };
+  return doFetch(upstream, upstreamBody, azureKey);
+}
 
-  const payload = {
-    method: request.method,
+async function proxyClassic(body, entry, cfg, endpoint, azureKey) {
+  if (entry.backend !== "oai") {
+    return errorResponse(400, "invalid_request_error",
+      `Model '${body.model}' is on backend '${entry.backend}' which does not support /${endpoint}`);
+  }
+  const apiVersion = entry.apiVersion || cfg.oaiApiVersion;
+  const upstream = `${cfg.oaiEndpoint}/openai/deployments/${entry.deployment}/${endpoint}?api-version=${apiVersion}`;
+  // Keep `model` in body as the deployment name — harmless for chat/completions,
+  // required by some endpoints (e.g. gpt-image-1 images/generations).
+  const upstreamBody = { ...body, model: entry.deployment };
+  return doFetch(upstream, upstreamBody, azureKey);
+}
+
+async function proxyInference(body, entry, cfg, endpoint, azureKey) {
+  if (!cfg.inferEndpoint) {
+    return errorResponse(500, "proxy_error", "AZURE_INFER_ENDPOINT is not set");
+  }
+  const upstream = `${cfg.inferEndpoint}/models/${endpoint}?api-version=${cfg.inferApiVersion}`;
+  const upstreamBody = { ...body, model: entry.deployment };
+  return doFetch(upstream, upstreamBody, azureKey);
+}
+
+async function doFetch(upstreamUrl, body, azureKey) {
+  if (!azureKey) {
+    return errorResponse(500, "proxy_error", "No Azure API key available (set AZURE_API_KEY or send Authorization header)");
+  }
+  const resp = await fetch(upstreamUrl, {
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "api-key": authKey.replace('Bearer ', ''),
+      "api-key": azureKey,
+      "Authorization": `Bearer ${azureKey}`
     },
-    body: typeof body === 'object' ? JSON.stringify(body) : '{}',
-  };
+    body: JSON.stringify(body)
+  });
 
-  let response = await fetch(fetchAPI, payload);
-  response = new Response(response.body, response);
-  response.headers.set("Access-Control-Allow-Origin", "*");
-
-  if (body?.stream != true){
-    return response
-  } 
-
-  let { readable, writable } = new TransformStream()
-  stream(response.body, writable);
-  return new Response(readable, response);
-
+  const headers = new Headers(resp.headers);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+  // Streams: let Workers pipe the body through natively.
+  return new Response(resp.body, { status: resp.status, headers });
 }
 
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+async function proxyMultipart(request, path, cfg) {
+  // Parse form to extract `model`, then rebuild (so we can still stream file parts).
+  const form = await request.formData();
+  const modelName = form.get("model");
+  if (!modelName) return errorResponse(400, "invalid_request_error", "Missing 'model' field in form");
+  const entry = cfg.mapping[modelName];
+  if (!entry) return errorResponse(400, "model_not_found", `Model '${modelName}' is not mapped`);
+  if (entry.backend !== "oai") {
+    return errorResponse(400, "invalid_request_error", `Model '${modelName}' does not support /${path}`);
+  }
+
+  // Rebuild form without `model` (classic endpoint ignores it; some reject)
+  const upstreamForm = new FormData();
+  for (const [k, v] of form.entries()) {
+    if (k === "model") continue;
+    upstreamForm.append(k, v);
+  }
+
+  const apiVersion = entry.apiVersion || cfg.oaiApiVersion;
+  const upstreamPath = path.replace(/^\//, "");
+  const upstream = `${cfg.oaiEndpoint}/openai/deployments/${entry.deployment}/${upstreamPath}?api-version=${apiVersion}`;
+  const azureKey = resolveAzureKey(request, cfg);
+
+  const resp = await fetch(upstream, {
+    method: "POST",
+    headers: { "api-key": azureKey, "Authorization": `Bearer ${azureKey}` },
+    body: upstreamForm
+  });
+  const headers = new Headers(resp.headers);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+  return new Response(resp.body, { status: resp.status, headers });
 }
 
-// support printer mode and add newline
-async function stream(readable, writable) {
-  const reader = readable.getReader();
-  const writer = writable.getWriter();
-
-  // const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  const decoder = new TextDecoder();
-// let decodedValue = decoder.decode(value);
-  const newline = "\n";
-  const delimiter = "\n\n"
-  const encodedNewline = encoder.encode(newline);
-
-  let buffer = "";
-  while (true) {
-    let { value, done } = await reader.read();
-    if (done) {
-      break;
-    }
-    buffer += decoder.decode(value, { stream: true }); // stream: true is important here,fix the bug of incomplete line
-    let lines = buffer.split(delimiter);
-
-    // Loop through all but the last line, which may be incomplete.
-    for (let i = 0; i < lines.length - 1; i++) {
-      await writer.write(encoder.encode(lines[i] + delimiter));
-      await sleep(20);
-    }
-
-    buffer = lines[lines.length - 1];
-  }
-
-  if (buffer) {
-    await writer.write(encoder.encode(buffer));
-  }
-  await writer.write(encodedNewline)
-  await writer.close();
-}
-
-async function handleModels(request) {
-  const data = {
-    "object": "list",
-    "data": []  
-  };
-
-  for (let key in mapper) {
-    data.data.push({
-      "id": key,
-      "object": "model",
-      "created": 1677610602,
-      "owned_by": "openai",
-      "permission": [{
-        "id": "modelperm-M56FXnG1AsIr3SXq8BYPvXJA",
-        "object": "model_permission",
-        "created": 1679602088,
-        "allow_create_engine": false,
-        "allow_sampling": true,
-        "allow_logprobs": true,
-        "allow_search_indices": false,
-        "allow_view": true,
-        "allow_fine_tuning": false,
-        "organization": "*",
-        "group": null,
-        "is_blocking": false
-      }],
-      "root": key,
-      "parent": null
-    });  
-  }
-
-  const json = JSON.stringify(data, null, 2);
-  return new Response(json, {
-    headers: { 'Content-Type': 'application/json' },
+function listModels(cfg) {
+  const data = Object.keys(cfg.mapping).map(id => ({
+    id,
+    object: "model",
+    created: 1677610602,
+    owned_by: cfg.mapping[id].backend === "infer" ? "azure-inference" : "azure-openai"
+  }));
+  return new Response(JSON.stringify({ object: "list", data }, null, 2), {
+    headers: { "Content-Type": "application/json", ...CORS_HEADERS }
   });
 }
 
-async function handleOPTIONS(request) {
-    return new Response(null, {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': '*',
-        'Access-Control-Allow-Headers': '*'
-      }
-    })
+function errorResponse(status, type, message) {
+  return new Response(
+    JSON.stringify({ error: { message, type, code: type } }),
+    { status, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+  );
 }
-

--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -17,9 +17,10 @@
 
 const DEFAULT_OAI_API_VERSION = "2025-04-01-preview";
 const DEFAULT_INFER_API_VERSION = "2024-05-01-preview";
-const DEFAULT_UPSTREAM_TIMEOUT_MS = 30000;
-const DEFAULT_CORS_ALLOW_HEADERS = "Authorization, Content-Type";
-const DEFAULT_CORS_EXPOSE_HEADERS = "openai-processing-ms, x-request-id";
+// Default governs time-to-first-byte. 120s accommodates reasoning models (o1,
+// gpt-5.x) whose non-streaming TTFB routinely exceeds 30s.
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 120000;
+const DEFAULT_CORS_ALLOW_HEADERS = "Authorization, Content-Type, api-key";
 const SAFE_RESPONSE_HEADERS = new Set([
   "cache-control",
   "content-disposition",
@@ -28,8 +29,30 @@ const SAFE_RESPONSE_HEADERS = new Set([
   "content-type",
   "openai-processing-ms",
   "retry-after",
+  "x-ratelimit-limit-requests",
+  "x-ratelimit-limit-tokens",
+  "x-ratelimit-remaining-requests",
+  "x-ratelimit-remaining-tokens",
+  "x-ratelimit-reset-requests",
+  "x-ratelimit-reset-tokens",
   "x-request-id"
 ]);
+// Expose to browser JS every safe header that isn't required by default (CORS
+// already exposes Cache-Control, Content-Language, Content-Type, Expires,
+// Last-Modified, Pragma).
+const DEFAULT_CORS_EXPOSE_HEADERS = [
+  "content-disposition",
+  "content-encoding",
+  "openai-processing-ms",
+  "retry-after",
+  "x-ratelimit-limit-requests",
+  "x-ratelimit-limit-tokens",
+  "x-ratelimit-remaining-requests",
+  "x-ratelimit-remaining-tokens",
+  "x-ratelimit-reset-requests",
+  "x-ratelimit-reset-tokens",
+  "x-request-id"
+].join(", ");
 const TEXT_ENCODER = new TextEncoder();
 
 let cachedModelMappingRaw = null;

--- a/cf-openai-azure-proxy.js
+++ b/cf-openai-azure-proxy.js
@@ -5,13 +5,35 @@
 //   3. Azure Model Inference  : {INFER}/models/{endpoint}?api-version=... (model in body, no deployment in URL)
 //
 // Required env vars (set in Workers dashboard -> Settings -> Variables):
-//   AZURE_API_KEY            (Secret) Shared key for both resources
+//   AZURE_API_KEY            (Secret) Shared key for both resources when CLIENT_API_KEYS is enabled
 //   AZURE_OAI_ENDPOINT       e.g. https://yoyo.cognitiveservices.azure.com
 //   AZURE_INFER_ENDPOINT     e.g. https://waytoagi.services.ai.azure.com
 //   AZURE_OAI_API_VERSION    default 2025-04-01-preview
 //   AZURE_INFER_API_VERSION  default 2024-05-01-preview
 //   MODEL_MAPPING            JSON string, see DEFAULT_MAPPING below
 //   CLIENT_API_KEYS          comma-separated list, e.g. sk-abc,sk-def (optional but recommended)
+//   ALLOWED_ORIGINS          comma-separated browser origins allowed by CORS (optional)
+//   UPSTREAM_TIMEOUT_MS      timeout for upstream Azure requests in milliseconds (optional)
+
+const DEFAULT_OAI_API_VERSION = "2025-04-01-preview";
+const DEFAULT_INFER_API_VERSION = "2024-05-01-preview";
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 30000;
+const DEFAULT_CORS_ALLOW_HEADERS = "Authorization, Content-Type";
+const DEFAULT_CORS_EXPOSE_HEADERS = "openai-processing-ms, x-request-id";
+const SAFE_RESPONSE_HEADERS = new Set([
+  "cache-control",
+  "content-disposition",
+  "content-encoding",
+  "content-language",
+  "content-type",
+  "openai-processing-ms",
+  "retry-after",
+  "x-request-id"
+]);
+const TEXT_ENCODER = new TextEncoder();
+
+let cachedModelMappingRaw = null;
+let cachedModelMapping = null;
 
 const DEFAULT_MAPPING = {
   // OpenAI-family on yoyo (classic + responses share the same entry;
@@ -39,23 +61,21 @@ const DEFAULT_MAPPING = {
   "llama-3.3-70b":         { backend: "infer", deployment: "llama-3.3-70b" }
 };
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Allow-Headers": "*"
-};
-
 export default {
   async fetch(request, env) {
+    let cfg;
     try {
+      cfg = loadConfig(env);
+
+      const originErr = checkOrigin(request, cfg);
+      if (originErr) return originErr;
+
       if (request.method === "OPTIONS") {
-        return new Response(null, { headers: CORS_HEADERS });
+        return new Response(null, { headers: getCorsHeaders(request, cfg) });
       }
 
-      const cfg = loadConfig(env);
       const url = new URL(request.url);
-      let path = url.pathname.replace(/\/+/g, "/");
-      if (path.startsWith("/v1/")) path = path.slice(3);
+      const path = normalizeClientPath(url.pathname);
 
       // Client auth
       const authErr = checkClientAuth(request, cfg);
@@ -63,7 +83,7 @@ export default {
 
       // Routes that don't need model lookup
       if (path === "/models" && request.method === "GET") {
-        return listModels(cfg);
+        return listModels(cfg, request);
       }
 
       // Multipart routes (audio + image edits) — must not json-parse the body
@@ -74,82 +94,165 @@ export default {
 
       // JSON routes
       if (request.method !== "POST") {
-        return errorResponse(404, "not_found", `No handler for ${request.method} ${path}`);
+        return errorResponse(404, "not_found", `No handler for ${request.method} ${path}`, request, cfg);
       }
 
       const body = await request.json().catch(() => null);
-      if (!body) return errorResponse(400, "invalid_request_error", "Request body must be valid JSON");
+      if (!body) {
+        return errorResponse(400, "invalid_request_error", "Request body must be valid JSON", request, cfg);
+      }
 
       const modelName = body.model;
-      if (!modelName) return errorResponse(400, "invalid_request_error", "Missing 'model' field in request body");
+      if (!modelName) {
+        return errorResponse(400, "invalid_request_error", "Missing 'model' field in request body", request, cfg, "model");
+      }
 
       const entry = cfg.mapping[modelName];
-      if (!entry) return errorResponse(400, "model_not_found", `Model '${modelName}' is not mapped. Update MODEL_MAPPING env var.`);
+      if (!entry) {
+        return errorResponse(400, "model_not_found", `Model '${modelName}' is not mapped. Update MODEL_MAPPING env var.`, request, cfg, "model");
+      }
 
       // Route by client path + backend
       const azureKey = resolveAzureKey(request, cfg);
       if (path === "/chat/completions") {
-        return proxyChatCompletions(body, entry, cfg, azureKey);
+        return proxyChatCompletions(request, body, entry, cfg, azureKey);
       }
       if (path === "/responses") {
-        return proxyResponses(body, entry, cfg, azureKey);
+        return proxyResponses(request, body, entry, cfg, azureKey);
       }
       if (path === "/completions") {
-        return proxyClassic(body, entry, cfg, "completions", azureKey);
+        return proxyClassic(request, body, entry, cfg, "completions", azureKey);
       }
       if (path === "/embeddings") {
-        if (entry.backend === "infer") return proxyInference(body, entry, cfg, "embeddings", azureKey);
-        return proxyClassic(body, entry, cfg, "embeddings", azureKey);
+        if (entry.backend === "infer") return proxyInference(request, body, entry, cfg, "embeddings", azureKey);
+        return proxyClassic(request, body, entry, cfg, "embeddings", azureKey);
       }
       if (path === "/images/generations") {
-        return proxyClassic(body, entry, cfg, "images/generations", azureKey);
+        return proxyClassic(request, body, entry, cfg, "images/generations", azureKey);
       }
       if (path === "/audio/speech") {
-        return proxyClassic(body, entry, cfg, "audio/speech", azureKey);
+        return proxyClassic(request, body, entry, cfg, "audio/speech", azureKey);
       }
 
-      return errorResponse(404, "not_found", `Unsupported path: ${url.pathname}`);
+      return errorResponse(404, "not_found", `Unsupported path: ${url.pathname}`, request, cfg);
     } catch (e) {
-      return errorResponse(500, "proxy_error", e.message || String(e));
+      return errorResponse(500, "proxy_error", e.message || String(e), request, cfg);
     }
   }
 };
 
 function loadConfig(env) {
-  let mapping = DEFAULT_MAPPING;
-  if (env.MODEL_MAPPING) {
-    try {
-      mapping = JSON.parse(env.MODEL_MAPPING);
-    } catch (e) {
-      throw new Error("MODEL_MAPPING is not valid JSON: " + e.message);
-    }
-  }
+  const mapping = parseModelMapping(env.MODEL_MAPPING || "");
+  const clientKeys = splitCsv(env.CLIENT_API_KEYS || "");
+  const allowedOrigins = splitCsv(env.ALLOWED_ORIGINS || "");
+  const azureKey = (env.AZURE_API_KEY || "").trim();
 
-  const clientKeys = (env.CLIENT_API_KEYS || "")
-    .split(",").map(s => s.trim()).filter(Boolean);
+  if (clientKeys.length > 0 && !azureKey) {
+    throw new Error("AZURE_API_KEY is required when CLIENT_API_KEYS is configured");
+  }
 
   return {
     mapping,
     clientKeys,
-    azureKey: env.AZURE_API_KEY || "",
+    allowedOrigins,
+    azureKey,
     oaiEndpoint: stripTrailingSlash(env.AZURE_OAI_ENDPOINT || ""),
     inferEndpoint: stripTrailingSlash(env.AZURE_INFER_ENDPOINT || ""),
-    oaiApiVersion: env.AZURE_OAI_API_VERSION || "2025-04-01-preview",
-    inferApiVersion: env.AZURE_INFER_API_VERSION || "2024-05-01-preview"
+    oaiApiVersion: env.AZURE_OAI_API_VERSION || DEFAULT_OAI_API_VERSION,
+    inferApiVersion: env.AZURE_INFER_API_VERSION || DEFAULT_INFER_API_VERSION,
+    upstreamTimeoutMs: parseUpstreamTimeoutMs(env.UPSTREAM_TIMEOUT_MS || "")
   };
 }
 
-function stripTrailingSlash(s) { return s.replace(/\/+$/, ""); }
+function parseModelMapping(raw) {
+  if (raw === cachedModelMappingRaw) return cachedModelMapping;
+
+  if (!raw) {
+    cachedModelMappingRaw = raw;
+    cachedModelMapping = DEFAULT_MAPPING;
+    return cachedModelMapping;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error("MODEL_MAPPING is not valid JSON: " + e.message);
+  }
+
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error("MODEL_MAPPING must be a JSON object");
+  }
+
+  cachedModelMappingRaw = raw;
+  cachedModelMapping = parsed;
+  return cachedModelMapping;
+}
+
+function parseUpstreamTimeoutMs(raw) {
+  if (!raw.trim()) return DEFAULT_UPSTREAM_TIMEOUT_MS;
+  const timeout = Number.parseInt(raw, 10);
+  if (!Number.isFinite(timeout) || timeout <= 0) {
+    throw new Error("UPSTREAM_TIMEOUT_MS must be a positive integer");
+  }
+  return timeout;
+}
+
+function splitCsv(raw) {
+  return raw.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function normalizeClientPath(pathname) {
+  const normalized = pathname.replace(/\/+/g, "/");
+  const withoutPrefix = normalized.replace(/^\/v1(?=\/|$)/, "");
+  return withoutPrefix || "/";
+}
+
+function stripTrailingSlash(s) {
+  return s.replace(/\/+$/, "");
+}
+
+function checkOrigin(request, cfg) {
+  if (cfg.allowedOrigins.length === 0) return null;
+
+  const origin = request.headers.get("Origin");
+  if (!origin) return null;
+
+  if (!cfg.allowedOrigins.includes(origin)) {
+    return errorResponse(403, "origin_not_allowed", "Origin is not allowed", request, cfg);
+  }
+  return null;
+}
 
 function checkClientAuth(request, cfg) {
   // If no CLIENT_API_KEYS configured, allow through (legacy mode: client supplies Azure key).
   if (cfg.clientKeys.length === 0) return null;
+
   const auth = request.headers.get("Authorization") || "";
   const key = auth.replace(/^Bearer\s+/i, "").trim();
-  if (!key || !cfg.clientKeys.includes(key)) {
-    return errorResponse(401, "invalid_api_key", "Invalid API key");
+  if (!key || !hasMatchingClientKey(key, cfg.clientKeys)) {
+    return errorResponse(401, "invalid_api_key", "Invalid API key", request, cfg);
   }
   return null;
+}
+
+function hasMatchingClientKey(key, clientKeys) {
+  for (const candidate of clientKeys) {
+    if (timingSafeEqual(key, candidate)) return true;
+  }
+  return false;
+}
+
+function timingSafeEqual(a, b) {
+  const left = TEXT_ENCODER.encode(a);
+  const right = TEXT_ENCODER.encode(b);
+  const maxLen = Math.max(left.length, right.length);
+  let diff = left.length ^ right.length;
+
+  for (let i = 0; i < maxLen; i += 1) {
+    diff |= (left[i] || 0) ^ (right[i] || 0);
+  }
+  return diff === 0;
 }
 
 function resolveAzureKey(request, cfg) {
@@ -158,75 +261,134 @@ function resolveAzureKey(request, cfg) {
   return auth.replace(/^Bearer\s+/i, "").trim();
 }
 
-async function proxyChatCompletions(body, entry, cfg, azureKey) {
+async function proxyChatCompletions(request, body, entry, cfg, azureKey) {
   if (entry.backend === "infer") {
-    return proxyInference(body, entry, cfg, "chat/completions", azureKey);
+    return proxyInference(request, body, entry, cfg, "chat/completions", azureKey);
   }
-  return proxyClassic(body, entry, cfg, "chat/completions", azureKey);
+  return proxyClassic(request, body, entry, cfg, "chat/completions", azureKey);
 }
 
-async function proxyResponses(body, entry, cfg, azureKey) {
+async function proxyResponses(request, body, entry, cfg, azureKey) {
   if (entry.backend !== "oai") {
-    return errorResponse(400, "invalid_request_error",
-      `Model '${body.model}' is on backend '${entry.backend}' which does not support /v1/responses`);
+    return errorResponse(
+      400,
+      "invalid_request_error",
+      `Model '${body.model}' is on backend '${entry.backend}' which does not support /v1/responses`,
+      request,
+      cfg,
+      "model"
+    );
   }
+  if (!cfg.oaiEndpoint) {
+    return errorResponse(500, "proxy_error", "AZURE_OAI_ENDPOINT is not set", request, cfg);
+  }
+
   const apiVersion = entry.apiVersion || cfg.oaiApiVersion;
   const upstream = `${cfg.oaiEndpoint}/openai/responses?api-version=${apiVersion}`;
   const upstreamBody = { ...body, model: entry.deployment };
-  return doFetch(upstream, upstreamBody, azureKey);
+  return fetchJsonUpstream(request, cfg, upstream, azureKey, upstreamBody);
 }
 
-async function proxyClassic(body, entry, cfg, endpoint, azureKey) {
+async function proxyClassic(request, body, entry, cfg, endpoint, azureKey) {
   if (entry.backend !== "oai") {
-    return errorResponse(400, "invalid_request_error",
-      `Model '${body.model}' is on backend '${entry.backend}' which does not support /${endpoint}`);
+    return errorResponse(
+      400,
+      "invalid_request_error",
+      `Model '${body.model}' is on backend '${entry.backend}' which does not support /${endpoint}`,
+      request,
+      cfg,
+      "model"
+    );
   }
+  if (!cfg.oaiEndpoint) {
+    return errorResponse(500, "proxy_error", "AZURE_OAI_ENDPOINT is not set", request, cfg);
+  }
+
   const apiVersion = entry.apiVersion || cfg.oaiApiVersion;
   const upstream = `${cfg.oaiEndpoint}/openai/deployments/${entry.deployment}/${endpoint}?api-version=${apiVersion}`;
   // Keep `model` in body as the deployment name — harmless for chat/completions,
   // required by some endpoints (e.g. gpt-image-1 images/generations).
   const upstreamBody = { ...body, model: entry.deployment };
-  return doFetch(upstream, upstreamBody, azureKey);
+  return fetchJsonUpstream(request, cfg, upstream, azureKey, upstreamBody);
 }
 
-async function proxyInference(body, entry, cfg, endpoint, azureKey) {
+async function proxyInference(request, body, entry, cfg, endpoint, azureKey) {
   if (!cfg.inferEndpoint) {
-    return errorResponse(500, "proxy_error", "AZURE_INFER_ENDPOINT is not set");
+    return errorResponse(500, "proxy_error", "AZURE_INFER_ENDPOINT is not set", request, cfg);
   }
+
   const upstream = `${cfg.inferEndpoint}/models/${endpoint}?api-version=${cfg.inferApiVersion}`;
   const upstreamBody = { ...body, model: entry.deployment };
-  return doFetch(upstream, upstreamBody, azureKey);
+  return fetchJsonUpstream(request, cfg, upstream, azureKey, upstreamBody);
 }
 
-async function doFetch(upstreamUrl, body, azureKey) {
-  if (!azureKey) {
-    return errorResponse(500, "proxy_error", "No Azure API key available (set AZURE_API_KEY or send Authorization header)");
-  }
-  const resp = await fetch(upstreamUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "api-key": azureKey,
-      "Authorization": `Bearer ${azureKey}`
-    },
-    body: JSON.stringify(body)
-  });
+async function fetchJsonUpstream(request, cfg, upstreamUrl, azureKey, body) {
+  return fetchUpstream(
+    request,
+    cfg,
+    upstreamUrl,
+    azureKey,
+    JSON.stringify(body),
+    { "Content-Type": "application/json" }
+  );
+}
 
-  const headers = new Headers(resp.headers);
-  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
-  // Streams: let Workers pipe the body through natively.
-  return new Response(resp.body, { status: resp.status, headers });
+async function fetchUpstream(request, cfg, upstreamUrl, azureKey, body, extraHeaders = {}) {
+  if (!azureKey) {
+    return errorResponse(500, "proxy_error", "No Azure API key available (set AZURE_API_KEY or send Authorization header)", request, cfg);
+  }
+
+  const headers = new Headers(extraHeaders);
+  headers.set("api-key", azureKey);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), cfg.upstreamTimeoutMs);
+
+  try {
+    const resp = await fetch(upstreamUrl, {
+      method: "POST",
+      headers,
+      body,
+      signal: controller.signal
+    });
+
+    return new Response(resp.body, {
+      status: resp.status,
+      headers: buildClientResponseHeaders(resp.headers, request, cfg)
+    });
+  } catch (e) {
+    if (e && e.name === "AbortError") {
+      return errorResponse(
+        504,
+        "upstream_timeout",
+        `Azure upstream timed out after ${cfg.upstreamTimeoutMs}ms`,
+        request,
+        cfg
+      );
+    }
+    throw e;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 async function proxyMultipart(request, path, cfg) {
   // Parse form to extract `model`, then rebuild (so we can still stream file parts).
   const form = await request.formData();
   const modelName = form.get("model");
-  if (!modelName) return errorResponse(400, "invalid_request_error", "Missing 'model' field in form");
+  if (typeof modelName !== "string" || !modelName) {
+    return errorResponse(400, "invalid_request_error", "Missing 'model' field in form", request, cfg, "model");
+  }
+
   const entry = cfg.mapping[modelName];
-  if (!entry) return errorResponse(400, "model_not_found", `Model '${modelName}' is not mapped`);
+  if (!entry) {
+    return errorResponse(400, "model_not_found", `Model '${modelName}' is not mapped`, request, cfg, "model");
+  }
   if (entry.backend !== "oai") {
-    return errorResponse(400, "invalid_request_error", `Model '${modelName}' does not support /${path}`);
+    return errorResponse(400, "invalid_request_error", `Model '${modelName}' does not support /${path}`, request, cfg, "model");
+  }
+  if (!cfg.oaiEndpoint) {
+    return errorResponse(500, "proxy_error", "AZURE_OAI_ENDPOINT is not set", request, cfg);
   }
 
   // Rebuild form without `model` (classic endpoint ignores it; some reject)
@@ -241,31 +403,82 @@ async function proxyMultipart(request, path, cfg) {
   const upstream = `${cfg.oaiEndpoint}/openai/deployments/${entry.deployment}/${upstreamPath}?api-version=${apiVersion}`;
   const azureKey = resolveAzureKey(request, cfg);
 
-  const resp = await fetch(upstream, {
-    method: "POST",
-    headers: { "api-key": azureKey, "Authorization": `Bearer ${azureKey}` },
-    body: upstreamForm
-  });
-  const headers = new Headers(resp.headers);
-  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
-  return new Response(resp.body, { status: resp.status, headers });
+  return fetchUpstream(request, cfg, upstream, azureKey, upstreamForm);
 }
 
-function listModels(cfg) {
-  const data = Object.keys(cfg.mapping).map(id => ({
+function buildClientResponseHeaders(upstreamHeaders, request, cfg) {
+  const headers = new Headers();
+
+  for (const [key, value] of upstreamHeaders.entries()) {
+    if (SAFE_RESPONSE_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  }
+
+  const corsHeaders = getCorsHeaders(request, cfg);
+  for (const [key, value] of corsHeaders.entries()) {
+    headers.set(key, value);
+  }
+  return headers;
+}
+
+function getCorsHeaders(request, cfg) {
+  const headers = new Headers();
+  const origin = request.headers.get("Origin");
+  const allowOrigin = resolveAllowedOrigin(origin, cfg);
+
+  if (allowOrigin) {
+    headers.set("Access-Control-Allow-Origin", allowOrigin);
+  }
+  headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  headers.set("Access-Control-Allow-Headers", request.headers.get("Access-Control-Request-Headers") || DEFAULT_CORS_ALLOW_HEADERS);
+  headers.set("Access-Control-Expose-Headers", DEFAULT_CORS_EXPOSE_HEADERS);
+  headers.set("Access-Control-Max-Age", "86400");
+
+  if (cfg && cfg.allowedOrigins.length > 0) appendVary(headers, "Origin");
+  if (request.headers.get("Access-Control-Request-Headers")) appendVary(headers, "Access-Control-Request-Headers");
+
+  return headers;
+}
+
+function resolveAllowedOrigin(origin, cfg) {
+  if (!cfg || cfg.allowedOrigins.length === 0) return "*";
+  if (!origin) return "";
+  return cfg.allowedOrigins.includes(origin) ? origin : "";
+}
+
+function appendVary(headers, value) {
+  const existing = headers.get("Vary");
+  if (!existing) {
+    headers.set("Vary", value);
+    return;
+  }
+
+  const values = existing.split(",").map((part) => part.trim()).filter(Boolean);
+  if (!values.includes(value)) values.push(value);
+  headers.set("Vary", values.join(", "));
+}
+
+function listModels(cfg, request) {
+  const created = Math.floor(Date.now() / 1000);
+  const data = Object.keys(cfg.mapping).map((id) => ({
     id,
     object: "model",
-    created: 1677610602,
+    created,
     owned_by: cfg.mapping[id].backend === "infer" ? "azure-inference" : "azure-openai"
   }));
+
   return new Response(JSON.stringify({ object: "list", data }, null, 2), {
-    headers: { "Content-Type": "application/json", ...CORS_HEADERS }
+    headers: buildClientResponseHeaders(new Headers({ "Content-Type": "application/json" }), request, cfg)
   });
 }
 
-function errorResponse(status, type, message) {
+function errorResponse(status, type, message, request, cfg, param = null) {
   return new Response(
-    JSON.stringify({ error: { message, type, code: type } }),
-    { status, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+    JSON.stringify({ error: { message, type, param, code: type } }),
+    {
+      status,
+      headers: buildClientResponseHeaders(new Headers({ "Content-Type": "application/json" }), request, cfg)
+    }
   );
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+DEV_VARS_FILE="/app/.dev.vars"
+GENERATED_VARS=0
+
+write_var() {
+  key="$1"
+  value="$2"
+
+  if [ -n "$value" ]; then
+    escaped=$(printf "%s" "$value" | sed "s/'/'\\\\''/g")
+    printf "%s='%s'\n" "$key" "$escaped" >> "$DEV_VARS_FILE"
+    GENERATED_VARS=1
+  fi
+}
+
+rm -f "$DEV_VARS_FILE"
+
+write_var "AZURE_API_KEY" "${AZURE_API_KEY:-}"
+write_var "AZURE_OAI_ENDPOINT" "${AZURE_OAI_ENDPOINT:-}"
+write_var "AZURE_INFER_ENDPOINT" "${AZURE_INFER_ENDPOINT:-}"
+write_var "CLIENT_API_KEYS" "${CLIENT_API_KEYS:-}"
+write_var "AZURE_OAI_API_VERSION" "${AZURE_OAI_API_VERSION:-}"
+write_var "AZURE_INFER_API_VERSION" "${AZURE_INFER_API_VERSION:-}"
+write_var "MODEL_MAPPING" "${MODEL_MAPPING:-}"
+
+if [ "$GENERATED_VARS" -eq 0 ]; then
+  rm -f "$DEV_VARS_FILE"
+fi
+
+exec wrangler dev --local --ip 0.0.0.0 --port 8787

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,16 @@
+name = "cf-openai-azure-proxy"
+main = "cf-openai-azure-proxy.js"
+compatibility_date = "2025-01-01"
+
+# Non-secret variables. Secrets (AZURE_API_KEY, CLIENT_API_KEYS) are set via:
+#   wrangler secret put AZURE_API_KEY
+#   wrangler secret put CLIENT_API_KEYS
+[vars]
+AZURE_OAI_ENDPOINT      = "https://yoyo.cognitiveservices.azure.com"
+AZURE_INFER_ENDPOINT    = "https://waytoagi.services.ai.azure.com"
+AZURE_OAI_API_VERSION   = "2025-04-01-preview"
+AZURE_INFER_API_VERSION = "2024-05-01-preview"
+
+# Inline MODEL_MAPPING here, or set it via `wrangler secret put MODEL_MAPPING`
+# to keep deployment names out of version control.
+# MODEL_MAPPING = '''{ "gpt-5.4": {"backend":"oai","deployment":"gpt-5.4"}, ... }'''

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,10 +13,12 @@ AZURE_OAI_ENDPOINT      = "https://yoyo.cognitiveservices.azure.com"
 AZURE_INFER_ENDPOINT    = "https://waytoagi.services.ai.azure.com"
 AZURE_OAI_API_VERSION   = "2025-04-01-preview"
 AZURE_INFER_API_VERSION = "2024-05-01-preview"
+# ALLOWED_ORIGINS       = "https://chat.example.com"
+# UPSTREAM_TIMEOUT_MS   = "30000"
 
 # Secrets — set via CLI, never commit them:
 #
-#   wrangler secret put AZURE_API_KEY        # Azure Foundry key (shared across both resources)
+#   wrangler secret put AZURE_API_KEY        # Required if CLIENT_API_KEYS is configured
 #   wrangler secret put CLIENT_API_KEYS      # sk-xxx,sk-yyy  (comma-separated client allowlist)
 #   wrangler secret put MODEL_MAPPING        # Optional — override the built-in mapping (JSON string)
 #

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,15 +2,58 @@ name = "cf-openai-azure-proxy"
 main = "cf-openai-azure-proxy.js"
 compatibility_date = "2025-01-01"
 
-# Non-secret variables. Secrets (AZURE_API_KEY, CLIENT_API_KEYS) are set via:
-#   wrangler secret put AZURE_API_KEY
-#   wrangler secret put CLIENT_API_KEYS
+# Enable logs in Cloudflare dashboard (Workers -> your worker -> Logs)
+[observability]
+enabled = true
+
+# Non-secret variables (visible in dashboard, committed to git).
+# Change these to your own Azure resource hostnames before deploying.
 [vars]
 AZURE_OAI_ENDPOINT      = "https://yoyo.cognitiveservices.azure.com"
 AZURE_INFER_ENDPOINT    = "https://waytoagi.services.ai.azure.com"
 AZURE_OAI_API_VERSION   = "2025-04-01-preview"
 AZURE_INFER_API_VERSION = "2024-05-01-preview"
 
-# Inline MODEL_MAPPING here, or set it via `wrangler secret put MODEL_MAPPING`
-# to keep deployment names out of version control.
-# MODEL_MAPPING = '''{ "gpt-5.4": {"backend":"oai","deployment":"gpt-5.4"}, ... }'''
+# Secrets — set via CLI, never commit them:
+#
+#   wrangler secret put AZURE_API_KEY        # Azure Foundry key (shared across both resources)
+#   wrangler secret put CLIENT_API_KEYS      # sk-xxx,sk-yyy  (comma-separated client allowlist)
+#   wrangler secret put MODEL_MAPPING        # Optional — override the built-in mapping (JSON string)
+#
+# Example MODEL_MAPPING JSON (paste as a single line when running the command):
+# {
+#   "gpt-5.4":               {"backend":"oai",   "deployment":"gpt-5.4"},
+#   "gpt-4o":                {"backend":"oai",   "deployment":"gpt-4o"},
+#   "gpt-4o-mini":           {"backend":"oai",   "deployment":"gpt-4o-mini"},
+#   "o1":                    {"backend":"oai",   "deployment":"o1"},
+#   "o3-mini":               {"backend":"oai",   "deployment":"o3-mini"},
+#   "gpt-image-1":           {"backend":"oai",   "deployment":"gpt-image-1",   "apiVersion":"2024-02-01"},
+#   "gpt-image-1.5":         {"backend":"oai",   "deployment":"gpt-image-1.5", "apiVersion":"2024-02-01"},
+#   "dall-e-3":              {"backend":"oai",   "deployment":"dall-e-3"},
+#   "text-embedding-3-small":{"backend":"oai",   "deployment":"text-embedding-3-small"},
+#   "text-embedding-3-large":{"backend":"oai",   "deployment":"text-embedding-3-large"},
+#   "whisper-1":             {"backend":"oai",   "deployment":"whisper-1"},
+#   "tts-1":                 {"backend":"oai",   "deployment":"tts-1"},
+#   "grok-4-20":             {"backend":"infer", "deployment":"grok-4-20"},
+#   "grok-3":                {"backend":"infer", "deployment":"grok-3"},
+#   "deepseek-r1":           {"backend":"infer", "deployment":"deepseek-r1"},
+#   "deepseek-v3":           {"backend":"infer", "deployment":"deepseek-v3"},
+#   "llama-3.3-70b":         {"backend":"infer", "deployment":"llama-3.3-70b"}
+# }
+
+# ------------------------------------------------------------
+# Deploy steps:
+#   npm i -g wrangler
+#   wrangler login
+#   wrangler secret put AZURE_API_KEY
+#   wrangler secret put CLIENT_API_KEYS
+#   wrangler deploy
+#
+# After deploy, your worker URL is printed. Use {URL}/v1 as the OpenAI
+# base URL in your client software, and a CLIENT_API_KEYS entry as the key.
+# ------------------------------------------------------------
+
+# Optional: bind a custom domain. Replace and uncomment:
+# [[routes]]
+# pattern = "api.yourdomain.com/*"
+# custom_domain = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,7 +14,7 @@ AZURE_INFER_ENDPOINT    = "https://waytoagi.services.ai.azure.com"
 AZURE_OAI_API_VERSION   = "2025-04-01-preview"
 AZURE_INFER_API_VERSION = "2024-05-01-preview"
 # ALLOWED_ORIGINS       = "https://chat.example.com"
-# UPSTREAM_TIMEOUT_MS   = "30000"
+# UPSTREAM_TIMEOUT_MS   = "120000"
 
 # Secrets — set via CLI, never commit them:
 #


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_UPSTREAM_TIMEOUT_MS` 30s → 120s. The 30s default was killing legitimate non-streaming calls to reasoning models (o1, gpt-5.x) whose TTFB routinely exceeds 30s. The timeout governs time-to-first-byte only; streaming bodies continue unaffected once they start.
- Whitelist `x-ratelimit-*` in `SAFE_RESPONSE_HEADERS` so OpenAI SDK clients can implement proper backoff instead of retrying blind after a 429.
- Align `Access-Control-Expose-Headers` with the safe-header whitelist so browser JS can actually read `retry-after` and `x-ratelimit-*`.
- Add `api-key` to the default `Access-Control-Allow-Headers` list.
- Sync `README.md` / `README_en.md` / `wrangler.toml` to the new 120000 default and clarify the TTFB-only semantics.

## Test plan
- [ ] Deploy to a staging Worker, hit `/v1/chat/completions` against `o1` with a long prompt, confirm no 504 before 30s.
- [ ] Inspect response headers from a 429 and confirm `x-ratelimit-*` reach the client.
- [ ] Browser smoke test: `fetch` from an allowed origin and `response.headers.get('x-ratelimit-remaining-requests')` returns a value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)